### PR TITLE
feat: validate end_time is in the future in create_auction

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -120,6 +120,9 @@ impl AuctionContract {
         if storage::auction_exists(&env, id) {
             soroban_sdk::panic_with_error!(&env, errors::AuctionError::AuctionNotOpen);
         }
+        if end_time <= env.ledger().timestamp() {
+            soroban_sdk::panic_with_error!(&env, errors::AuctionError::AuctionNotClosed);
+        }
         storage::auction_set_seller(&env, id, &seller);
         storage::auction_set_asset(&env, id, &asset);
         storage::auction_set_min_bid(&env, id, min_bid);

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -307,6 +307,16 @@ fn test_claim_not_winner_fails() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_create_auction_past_end_time_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, seller, asset) = setup(&env);
+    env.ledger().set_timestamp(2000);
+    client.create_auction(&1, &seller, &asset, &100, &1000u64);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #8)")]
 fn test_create_duplicate_auction_fails() {
     let env = Env::default();


### PR DESCRIPTION

## What
Added a guard in create_auction that panics with AuctionNotClosed if end_time <= env.ledger().timestamp().

## Changes
- lib.rs — added end_time validation before storing auction state
- test.rs — added test_create_auction_past_end_time_fails to cover the new guard

## Test
cargo test  ✓ 30 passed
cargo clippy  ✓ no warnings

## Closes: #267 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auction creation now validates the end time against the current timestamp. Auctions with end times in the past are rejected to prevent invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->