### PR TITLE
 feat: add withdraw function to escrow

### DIFF
--- a/gateway-contract/contracts/escrow_contract/src/lib.rs
+++ b/gateway-contract/contracts/escrow_contract/src/lib.rs
@@ -353,6 +353,37 @@ impl EscrowContract {
         Events::vault_cancel(&env, commitment, refunded_amount);
     }
 
+    /// Withdraws tokens from an active vault back to the owner.
+    ///
+    /// The vault owner must authorize this call. The vault remains active and
+    /// its balance is reduced by the withdrawn amount.
+    pub fn withdraw(env: Env, commitment: BytesN<32>, amount: i128) {
+        if amount <= 0 {
+            panic_with_error!(&env, EscrowError::InvalidAmount);
+        }
+
+        let config = read_vault_config(&env, &commitment)
+            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::VaultNotFound));
+        let mut state = read_vault_state(&env, &commitment)
+            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::VaultNotFound));
+
+        config.owner.require_auth();
+
+        if !state.is_active {
+            panic_with_error!(&env, EscrowError::VaultInactive);
+        }
+
+        if state.balance < amount {
+            panic_with_error!(&env, EscrowError::InsufficientBalance);
+        }
+
+        state.balance -= amount;
+        write_vault_state(&env, &commitment, &state);
+
+        let token_client = token::Client::new(&env, &config.token);
+        token_client.transfer(&env.current_contract_address(), &config.owner, &amount);
+    }
+
     /// Registers a recurring payment rule.
     ///
     /// Once registered, calling `trigger_auto_pay` will send `amount` tokens

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -618,6 +618,51 @@ fn test_deposit_invalid_amount() {
 }
 
 #[test]
+fn test_withdraw_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, token, token_admin, from, _) = setup_test(&env);
+
+    let owner = Address::generate(&env);
+    let initial_balance = 1_000i128;
+    let withdraw_amount = 400i128;
+
+    create_vault(&env, &contract_id, &from, &owner, &token, initial_balance);
+
+    let token_admin_client = StellarAssetClient::new(&env, &token);
+    token_admin_client.mint(&contract_id, &withdraw_amount);
+
+    client.withdraw(&from, &withdraw_amount);
+
+    env.as_contract(&contract_id, || {
+        let state: VaultState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VaultState(from.clone()))
+            .unwrap();
+        assert_eq!(state.balance, initial_balance - withdraw_amount);
+        assert!(state.is_active);
+    });
+
+    let token_client = TokenClient::new(&env, &token);
+    assert_eq!(token_client.balance(&owner), withdraw_amount);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_withdraw_insufficient_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, token, _token_admin, from, _) = setup_test(&env);
+
+    let owner = Address::generate(&env);
+    create_vault(&env, &contract_id, &from, &owner, &token, 100);
+
+    let result = client.try_withdraw(&from, &200);
+    assert_eq!(result, Err(Ok(EscrowError::InsufficientBalance)));
+}
+
+#[test]
 #[should_panic]
 fn test_deposit_not_owner() {
     let env = Env::default();


### PR DESCRIPTION
Close #281 

## PR Summary

Adds a new `withdraw` function to the escrow contract so vault owners can withdraw funds without cancelling the entire vault.

## What changed

- lib.rs
  - Added `EscrowContract::withdraw(env, commitment, amount)`
  - Requires owner authorization
  - Checks that the vault exists and is active
  - Validates `amount > 0`
  - Checks sufficient vault balance
  - Deducts the amount from the vault balance
  - Transfers tokens from the contract back to the vault owner

- test.rs
  - Added `test_withdraw_success`
  - Added `test_withdraw_insufficient_balance`

## Behavior

- Vault owners can withdraw from an active vault
- Vault remains active after withdrawal
- Vault balance is reduced by the withdrawn amount
- Withdrawals fail if:
  - vault is inactive
  - vault does not exist
  - amount is invalid
  - balance is insufficient
  - caller is not the vault owner

## Testing

- `cargo test` under escrow_contract

## Notes

- Implementation follows the requested acceptance criteria
- New tests cover success and insufficient balance conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented withdrawal functionality for escrow contracts, enabling authorized vault owners to withdraw their funds with built-in validation checks for authorization, vault status, and balance availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->