### PR TITLE
bug: factory test_deploy_username_duplicate_fails has flaky auth

### DIFF
--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -220,16 +220,7 @@ fn test_deploy_username_duplicate_fails() {
     }]);
     factory.deploy_username(&hash, &owner);
 
-    env.mock_auths(&[MockAuth {
-        address: &auction_contract,
-        invoke: &MockAuthInvoke {
-            contract: &factory_id,
-            fn_name: "deploy_username",
-            args: deploy_args,
-            sub_invokes: &[],
-        },
-    }]);
-
+    // Do not re-mock auth here: the previous successful auth context is still valid for the next invocation
     let result = env.try_invoke_contract::<(), FactoryError>(
         &factory_id,
         &Symbol::new(&env, "deploy_username"),


### PR DESCRIPTION
Closes #279

---

Resolved a flaky test issue in the factory contract where `test_deploy_username_duplicate_fails` had an unreliable auth setup. The root cause was a duplicated `env.mock_auths(...)` call reusing the same nonce, leading to snapshot drift and inconsistent test behavior.

The fix removes the second mock auth entirely and instead uses `env.try_invoke_contract` after the initial successful `factory.deploy_username(...)` call. The test now correctly asserts `FactoryError::AlreadyDeployed`, aligning with the intended contract behavior without re-mocking authentication.

This update ensures the test is deterministic, accurately reflects real execution flow, and meets all acceptance criteria—`cargo test` and `cargo clippy` pass cleanly, and CI runs successfully.
