### PR TITLE
docs: add doc comments to all EscrowContract public functions

### DIFF
--- a/gateway-contract/contracts/escrow_contract/src/lib.rs
+++ b/gateway-contract/contracts/escrow_contract/src/lib.rs
@@ -113,6 +113,10 @@ impl EscrowContract {
     /// The vault owner must authorize this call. Tokens are transferred from the
     /// owner to this contract before the vault balance is updated.
     ///
+    /// ### Arguments
+    /// - `commitment`: The `BytesN<32>` identity commitment of the vault.
+    /// - `amount`: The amount of tokens to deposit. Must be > 0.
+    ///
     /// ### Errors
     /// - `InvalidAmount`: If `amount <= 0`.
     /// - `VaultNotFound`: If the vault does not exist.
@@ -297,6 +301,20 @@ impl EscrowContract {
         Ok(payment_id)
     }
 
+    /// Executes a previously scheduled payment once its release time has passed.
+    ///
+    /// Transfers the reserved tokens from this contract to the resolved owner of
+    /// the destination vault. Can be called by anyone (trustless keeper/bot).
+    ///
+    /// ### Arguments
+    /// - `payment_id`: The unique ID returned by [`EscrowContract::schedule_payment`].
+    ///
+    /// ### Errors
+    /// - `PaymentNotFound`: If no payment exists for `payment_id`.
+    /// - `PaymentAlreadyExecuted`: If the payment has already been executed.
+    /// - `PaymentNotYetDue`: If the current ledger time is before `release_at`.
+    /// - `VaultNotFound`: If the source vault no longer exists.
+    /// - `VaultInactive`: If the source vault has been cancelled.
     pub fn execute_scheduled(env: Env, payment_id: u32) {
         soroban_sdk::log!(
             &env,
@@ -375,6 +393,12 @@ impl EscrowContract {
     ///
     /// Marks the vault as inactive and refunds any remaining balance to the owner.
     /// Once cancelled, no new deposits/payments/auto-pays should be triggerable on it.
+    ///
+    /// ### Arguments
+    /// - `commitment`: The `BytesN<32>` identity commitment of the vault to cancel.
+    ///
+    /// ### Errors
+    /// - `VaultNotFound`: If no vault exists for `commitment`.
     pub fn cancel_vault(env: Env, commitment: BytesN<32>) {
         // 1) Load vault config + authenticate as owner.
         let config = read_vault_config(&env, &commitment)

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -7,9 +7,7 @@ use crate::EscrowContractClient;
 use soroban_sdk::testutils::{Address as _, Events as _, Ledger, MockAuth, MockAuthInvoke};
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 
-use soroban_sdk::{
-    contract, contractimpl, Address, BytesN, Env, Error, IntoVal, Symbol, TryFromVal,
-};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Error, IntoVal};
 
 // ---------------------------------------------------------------------------
 // Mock Registration contract — exposes get_owner / set_owner for tests.
@@ -88,7 +86,7 @@ fn mint_token(env: &Env, token: &Address, token_admin: &Address, to: &Address, a
     assert_eq!(admin_client.admin(), *token_admin);
 }
 
-fn read_vault(env: &Env, contract_id: &Address, id: &BytesN<32>) -> VaultState {
+fn _read_vault(env: &Env, contract_id: &Address, id: &BytesN<32>) -> VaultState {
     env.as_contract(contract_id, || {
         env.storage()
             .persistent()


### PR DESCRIPTION
## Summary

Closes #285

Adds `///` doc comments to all previously undocumented public functions in `EscrowContract`:

- `execute_scheduled` — added full doc block with `### Arguments` and `### Errors` listing all error variants
- `cancel_vault` — added `### Arguments` and `### Errors` sections to the existing partial doc block
- `deposit` — added missing `### Arguments` section

Also fixed two pre-existing warnings in `test.rs` (unused imports `Symbol`/`TryFromVal` and dead function `read_vault`).

## Verification

- `cargo doc --no-deps` — no warnings
- `cargo test -p escrow_contract` — 36 passed, 0 warnings
- `cargo clippy -p escrow_contract -- -D warnings` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scheduled payment execution capability, enabling payments to be processed at designated times with validation checks for payment status, vault availability, and timing requirements.

* **Documentation**
  * Enhanced deposit operation documentation with explicit parameter descriptions.
  * Updated vault cancellation documentation with additional details on error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->