### PR TITLE
fix: alien-gateway transfer to same owner must fail with clear error

### DIFF
--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -955,6 +955,22 @@ fn test_transfer_same_owner_panics() {
     client.transfer(&owner, &hash, &owner, &dummy_proof(&env), &signals);
 }
 
+/// Verifies that `transfer_ownership` rejects a same-owner transfer with `SameOwner` (#8).
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_transfer_ownership_same_owner_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 35);
+
+    client.register(&owner, &hash);
+    // new_owner == current owner must return SameOwner (#8), not a generic host error.
+    client.transfer_ownership(&owner, &hash, &owner);
+}
+
 #[test]
 #[should_panic(expected = "Error(Contract, #7)")]
 fn test_transfer_non_owner_panics() {


### PR DESCRIPTION
## Summary

Closes #299

The `SameOwner` guard was already present in both `Transfer::transfer` and `Transfer::transfer_ownership` (returning `CoreError::SameOwner = 8`), but `transfer_ownership` had no dedicated test to confirm the descriptive error code rather than a generic host error.

## Changes

- `core_contract/src/test.rs`: Added `test_transfer_ownership_same_owner_fails` — asserts that calling `transfer_ownership` with `new_owner == current_owner` panics with `Error(Contract, #8)` (SameOwner).

## Verification

- `cargo test -p core_contract` — 66 passed, 0 warnings ✅
- `cargo clippy -p core_contract -- -D warnings` — clean ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify ownership transfer validation prevents transfers to the same owner, improving code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->