### PR TITLE
#309 chore: add clippy lint configuration to workspace Cargo.toml

### DIFF
--- a/gateway-contract/Cargo.toml
+++ b/gateway-contract/Cargo.toml
@@ -8,6 +8,10 @@ members = [
   "tests",
 ]
 
+[workspace.lints.clippy]
+missing_docs_in_private_items = "warn"
+unwrap_used = "warn"
+
 [workspace.dependencies]
 soroban-sdk = "23"
 

--- a/gateway-contract/contracts/auction_contract/Cargo.toml
+++ b/gateway-contract/contracts/auction_contract/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 crate-type = ["lib", "cdylib"]
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 soroban-sdk = { workspace = true }
 

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -9,6 +9,8 @@ pub mod types;
 // Ensure event symbols are linked from the main contract entrypoint module.
 use crate::events::{AUCTION_CLOSED, AUCTION_CREATED, BID_PLACED, BID_REFUNDED, USERNAME_CLAIMED};
 
+/// Ensures event symbol constants are referenced from the crate root so the
+/// linker does not strip them when compiling to WASM.
 #[allow(dead_code)]
 fn _touch_event_symbols() {
     let _ = (

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -85,7 +85,7 @@ pub fn auction_get_seller(env: &Env, id: u32) -> Address {
     env.storage()
         .persistent()
         .get(&AuctionKey::Seller(id))
-        .unwrap()
+        .expect("seller must be set before auction close")
 }
 
 pub fn auction_set_seller(env: &Env, id: u32, seller: &Address) {
@@ -102,7 +102,7 @@ pub fn auction_get_asset(env: &Env, id: u32) -> Address {
     env.storage()
         .persistent()
         .get(&AuctionKey::Asset(id))
-        .unwrap()
+        .expect("asset must be set at auction creation")
 }
 
 pub fn auction_set_asset(env: &Env, id: u32, asset: &Address) {

--- a/gateway-contract/contracts/auction_contract/test_snapshots/test/test_create_auction_past_end_time_fails.1.json
+++ b/gateway-contract/contracts/auction_contract/test_snapshots/test/test_create_auction_past_end_time_fails.1.json
@@ -1,0 +1,269 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 2000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+                "balance": "0",
+                "seq_num": "0",
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/core_contract/Cargo.toml
+++ b/gateway-contract/contracts/core_contract/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 crate-type = ["lib", "cdylib"]
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 soroban-sdk = { workspace = true }
 

--- a/gateway-contract/contracts/core_contract/test_snapshots/test/test_transfer_ownership_same_owner_fails.1.json
+++ b/gateway-contract/contracts/core_contract/test_snapshots/test/test_transfer_ownership_same_owner_fails.1.json
@@ -1,0 +1,177 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "2323232323232323232323232323232323232323232323232323232323232323"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Commitment"
+                },
+                {
+                  "bytes": "2323232323232323232323232323232323232323232323232323232323232323"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Commitment"
+                    },
+                    {
+                      "bytes": "2323232323232323232323232323232323232323232323232323232323232323"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/escrow_contract/Cargo.toml
+++ b/gateway-contract/contracts/escrow_contract/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 crate-type = ["lib", "cdylib"]
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 soroban-sdk = { workspace = true }
 

--- a/gateway-contract/contracts/escrow_contract/src/lib.rs
+++ b/gateway-contract/contracts/escrow_contract/src/lib.rs
@@ -579,6 +579,8 @@ impl EscrowContract {
     }
 }
 
+/// Returns the owner address of the vault identified by `commitment`, panicking
+/// with `VaultNotFound` if no vault config exists.
 fn resolve(env: &Env, commitment: &BytesN<32>) -> Address {
     let config = read_vault_config(env, commitment)
         .unwrap_or_else(|| panic_with_error!(env, EscrowError::VaultNotFound));

--- a/gateway-contract/contracts/factory_contract/Cargo.toml
+++ b/gateway-contract/contracts/factory_contract/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 crate-type = ["lib", "cdylib"]
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 soroban-sdk = { workspace = true }
 

--- a/gateway-contract/contracts/factory_contract/src/errors.rs
+++ b/gateway-contract/contracts/factory_contract/src/errors.rs
@@ -3,8 +3,12 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
+/// Errors returned by the factory contract.
 pub enum FactoryError {
+    /// Caller is not the configured auction contract.
     Unauthorized = 1,
+    /// Username hash is already registered.
     AlreadyDeployed = 2,
+    /// Core contract address has not been configured.
     CoreContractNotConfigured = 3,
 }

--- a/gateway-contract/contracts/factory_contract/src/events.rs
+++ b/gateway-contract/contracts/factory_contract/src/events.rs
@@ -1,9 +1,12 @@
 use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
 
+/// Event topic emitted when a new username is deployed.
 pub const USERNAME_DEPLOYED: Symbol = symbol_short!("USR_DEP");
+/// Event topic emitted when username ownership is transferred.
 #[allow(dead_code)]
 pub const OWNERSHIP_TRANSFERRED: Symbol = symbol_short!("OWN_TRF");
 
+/// Emits an event recording the deployment of a new username record.
 #[allow(deprecated)]
 pub fn emit_username_deployed(
     env: &Env,
@@ -17,6 +20,7 @@ pub fn emit_username_deployed(
     );
 }
 
+/// Emits an event recording a username ownership transfer.
 #[allow(dead_code)]
 #[allow(deprecated)]
 pub fn emit_ownership_transferred(

--- a/gateway-contract/contracts/factory_contract/src/lib.rs
+++ b/gateway-contract/contracts/factory_contract/src/lib.rs
@@ -1,8 +1,12 @@
 #![no_std]
 
+/// Error types returned by the factory contract.
 mod errors;
+/// Event emission helpers.
 mod events;
+/// Persistent storage accessors.
 mod storage;
+/// Shared data structures.
 mod types;
 
 #[cfg(test)]

--- a/gateway-contract/contracts/factory_contract/src/storage.rs
+++ b/gateway-contract/contracts/factory_contract/src/storage.rs
@@ -8,39 +8,49 @@ pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
 /// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 
+/// Storage keys used by the factory contract.
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    /// Address of the auction contract authorised to deploy usernames.
     AuctionContract,
+    /// Address of the core contract associated with new usernames.
     CoreContract,
+    /// Record for a registered username, keyed by its 32-byte hash.
     Username(BytesN<32>),
+    /// Optional deployment configuration for the factory.
     Config,
 }
 
+/// Persists the auction contract address in instance storage.
 pub fn set_auction_contract(env: &Env, auction_contract: &Address) {
     env.storage()
         .instance()
         .set(&DataKey::AuctionContract, auction_contract);
 }
 
+/// Returns the configured auction contract address, or `None` if unset.
 pub fn get_auction_contract(env: &Env) -> Option<Address> {
     env.storage()
         .instance()
         .get::<DataKey, Address>(&DataKey::AuctionContract)
 }
 
+/// Persists the core contract address in instance storage.
 pub fn set_core_contract(env: &Env, core_contract: &Address) {
     env.storage()
         .instance()
         .set(&DataKey::CoreContract, core_contract);
 }
 
+/// Returns the configured core contract address, or `None` if unset.
 pub fn get_core_contract(env: &Env) -> Option<Address> {
     env.storage()
         .instance()
         .get::<DataKey, Address>(&DataKey::CoreContract)
 }
 
+/// Stores a username record in persistent storage, extending its TTL.
 pub fn set_username(env: &Env, hash: &BytesN<32>, record: &UsernameRecord) {
     let key = DataKey::Username(hash.clone());
     env.storage().persistent().set(&key, record);
@@ -51,18 +61,21 @@ pub fn set_username(env: &Env, hash: &BytesN<32>, record: &UsernameRecord) {
     );
 }
 
+/// Returns the username record for the given hash, or `None` if not registered.
 pub fn get_username(env: &Env, hash: &BytesN<32>) -> Option<UsernameRecord> {
     env.storage()
         .persistent()
         .get::<DataKey, UsernameRecord>(&DataKey::Username(hash.clone()))
 }
 
+/// Returns `true` if a username record exists for the given hash.
 pub fn has_username(env: &Env, hash: &BytesN<32>) -> bool {
     env.storage()
         .persistent()
         .has(&DataKey::Username(hash.clone()))
 }
 
+/// Returns the deploy configuration, or `None` if not set.
 #[allow(dead_code)]
 pub fn get_config(env: &Env) -> Option<DeployConfig> {
     env.storage()
@@ -70,6 +83,7 @@ pub fn get_config(env: &Env) -> Option<DeployConfig> {
         .get::<DataKey, DeployConfig>(&DataKey::Config)
 }
 
+/// Persists the deploy configuration in persistent storage, extending its TTL.
 #[allow(dead_code)]
 pub fn set_config(env: &Env, config: &DeployConfig) {
     let key = DataKey::Config;

--- a/gateway-contract/contracts/factory_contract/src/types.rs
+++ b/gateway-contract/contracts/factory_contract/src/types.rs
@@ -2,16 +2,24 @@ use soroban_sdk::{contracttype, Address, BytesN};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// On-chain record for a registered username.
 pub struct UsernameRecord {
+    /// 32-byte hash that uniquely identifies the username.
     pub username_hash: BytesN<32>,
+    /// Address that owns this username.
     pub owner: Address,
+    /// Ledger timestamp at which the username was registered.
     pub registered_at: u64,
+    /// Core contract address associated with this username.
     pub core_contract: Address,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+/// Configuration required to deploy a new core contract instance.
 pub struct DeployConfig {
+    /// WASM hash of the core contract to be instantiated.
     pub core_contract_wasm_hash: BytesN<32>,
+    /// Admin address authorised to manage the factory.
     pub admin: Address,
 }

--- a/gateway-contract/tests/Cargo.toml
+++ b/gateway-contract/tests/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 
 
+[lints]
+workspace = true
+
 [dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 core_contract = { path = "../contracts/core_contract" }


### PR DESCRIPTION
Chore: Enforce Clippy Lint Rules Across Workspace
Adds missing_docs_in_private_items and unwrap_used as workspace-level Clippy warnings in Cargo.toml, and fixes all resulting warnings in contract source files to ensure CI compliance.


Closes #309 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation across all contracts for improved code clarity.

* **Bug Fixes**
  * Improved error messages for better debugging and failure identification.

* **Chores**
  * Standardized code linting configuration across the workspace.
  * Added test snapshots to validate contract behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->