### PR TITLE
bug: factory TTL not extended when reading existing username records

### DIFF
--- a/gateway-contract/contracts/factory_contract/src/storage.rs
+++ b/gateway-contract/contracts/factory_contract/src/storage.rs
@@ -52,9 +52,19 @@ pub fn set_username(env: &Env, hash: &BytesN<32>, record: &UsernameRecord) {
 }
 
 pub fn get_username(env: &Env, hash: &BytesN<32>) -> Option<UsernameRecord> {
-    env.storage()
+    let key = DataKey::Username(hash.clone());
+    let record = env
+        .storage()
         .persistent()
-        .get::<DataKey, UsernameRecord>(&DataKey::Username(hash.clone()))
+        .get::<DataKey, UsernameRecord>(&key);
+    if record.is_some() {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+    record
 }
 
 pub fn has_username(env: &Env, hash: &BytesN<32>) -> bool {

--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -1,6 +1,8 @@
 #![cfg(test)]
 
-use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::testutils::{
+    storage::Persistent as _, Address as _, Events as _, Ledger as _, MockAuth, MockAuthInvoke,
+};
 use soroban_sdk::{contract, contractimpl, IntoVal, Symbol, TryFromVal, Val, Vec};
 use soroban_sdk::{Address, BytesN, Env};
 
@@ -280,4 +282,43 @@ fn test_get_owner_none_for_unknown() {
     let unknown_hash = BytesN::from_array(&env, &[99; 32]);
     let record = factory.get_username_record(&unknown_hash);
     assert!(record.is_none());
+}
+
+#[test]
+fn get_username_record_extends_ttl_on_read() {
+    use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
+
+    let env = Env::default();
+    let (factory_id, factory, auction_contract, _) = setup_factory(&env);
+    let owner = Address::generate(&env);
+    let hash = username_hash(&env);
+    let deploy_args: Vec<Val> = (hash.clone(), owner.clone()).into_val(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "deploy_username",
+            args: deploy_args,
+            sub_invokes: &[],
+        },
+    }]);
+    factory.deploy_username(&hash, &owner);
+
+    // Advance the ledger so the remaining TTL drops below the lifetime threshold.
+    env.ledger().with_mut(|l| {
+        l.sequence_number += (PERSISTENT_BUMP_AMOUNT - PERSISTENT_LIFETIME_THRESHOLD + 1) as u32;
+    });
+
+    // Reading the record should bump the TTL back to PERSISTENT_BUMP_AMOUNT.
+    let record = factory.get_username_record(&hash);
+    assert!(record.is_some());
+
+    env.as_contract(&factory_id, || {
+        let ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&DataKey::Username(hash.clone()));
+        assert_eq!(ttl, PERSISTENT_BUMP_AMOUNT);
+    });
 }


### PR DESCRIPTION
## Summary
- `get_username` in `storage.rs` was reading the record but never calling `extend_ttl`, causing live records to silently age out
- Added `extend_ttl` on every successful read, mirroring the pattern already used in `set_username`
- Added `get_username_record_extends_ttl_on_read` test to verify the TTL is bumped back to `PERSISTENT_BUMP_AMOUNT` after the ledger advances past the lifetime threshold

## Changes
- `gateway-contract/contracts/factory_contract/src/storage.rs`: extend TTL in `get_username` when record is found
- `gateway-contract/contracts/factory_contract/src/test.rs`: new test verifying TTL extension on read

## Test plan
- [x] All 10 tests pass (`cargo test`)
- [x] `cargo clippy` passes with no warnings
- [x] New test `get_username_record_extends_ttl_on_read` confirms TTL is bumped after ledger advances

Closes #274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved username record retrieval to maintain data availability when accessed.
  
* **Tests**
  * Added test coverage for username record data persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->