### PR TITLE
fix: close_auction_by_id does not validate auction exists

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -152,6 +152,9 @@ impl AuctionContract {
     }
 
     pub fn close_auction_by_id(env: Env, id: u32) {
+        if !storage::auction_exists(&env, id) {
+            soroban_sdk::panic_with_error!(&env, errors::AuctionError::AuctionNotOpen);
+        }
         let end_time = storage::auction_get_end_time(&env, id);
         if env.ledger().timestamp() < end_time {
             soroban_sdk::panic_with_error!(&env, errors::AuctionError::AuctionNotClosed);

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -290,6 +290,15 @@ fn test_close_auction_early_fails() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_close_nonexistent_auction_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup(&env);
+    client.close_auction_by_id(&999);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #1)")]
 fn test_claim_not_winner_fails() {
     let env = Env::default();


### PR DESCRIPTION
## Summary

Closes #263

`auction_get_end_time` returns `0` for missing auctions, so a nonexistent id always passed the timestamp check. Added an `auction_exists` guard before the end-time check that panics with `AuctionNotOpen` (#8) if the auction is missing.

## Changes

- `auction_contract/src/lib.rs`: Added `auction_exists` guard at the top of `close_auction_by_id`
- `auction_contract/src/test.rs`: Added `test_close_nonexistent_auction_fails`

## Verification

- `cargo test -p auction_contract` — 20 passed ✅
- `cargo clippy -p auction_contract -- -D warnings` — clean ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when attempting to close an auction that does not exist, ensuring explicit validation before processing.

* **Tests**
  * Added test coverage for error scenarios when closing non-existent auctions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->