### PR TITLE
feat: alien-gateway reject SmtRoot update when new root equals current

### DIFF
--- a/gateway-contract/contracts/core_contract/src/admin.rs
+++ b/gateway-contract/contracts/core_contract/src/admin.rs
@@ -77,7 +77,11 @@ impl Admin {
             .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
         owner.require_auth();
 
-        if let Some(current) = env.storage().instance().get::<_, soroban_sdk::BytesN<32>>(&storage::DataKey::SmtRoot) {
+        if let Some(current) = env
+            .storage()
+            .instance()
+            .get::<_, soroban_sdk::BytesN<32>>(&storage::DataKey::SmtRoot)
+        {
             if current == new_root {
                 panic_with_error!(&env, CoreError::RootUnchanged);
             }

--- a/gateway-contract/contracts/core_contract/src/admin.rs
+++ b/gateway-contract/contracts/core_contract/src/admin.rs
@@ -77,6 +77,12 @@ impl Admin {
             .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
         owner.require_auth();
 
+        if let Some(current) = env.storage().instance().get::<_, soroban_sdk::BytesN<32>>(&storage::DataKey::SmtRoot) {
+            if current == new_root {
+                panic_with_error!(&env, CoreError::RootUnchanged);
+            }
+        }
+
         smt_root::SmtRoot::update_root(&env, new_root);
     }
 }

--- a/gateway-contract/contracts/core_contract/src/errors.rs
+++ b/gateway-contract/contracts/core_contract/src/errors.rs
@@ -24,6 +24,8 @@ pub enum CoreError {
     AlreadyInitialized = 9,
     /// Commitment is already registered via register().
     AlreadyRegistered = 10,
+    /// The new SMT root is identical to the current root.
+    RootUnchanged = 11,
 }
 
 #[contracterror]

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -688,6 +688,22 @@ fn test_update_smt_root_unauthorized_rejects() {
     client.update_smt_root(&new_root);
 }
 
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_update_smt_root_same_root_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    let root = BytesN::from_array(&env, &[42u8; 32]);
+    client.update_smt_root(&root);
+    // Setting the same root again must fail with RootUnchanged (#11)
+    client.update_smt_root(&root);
+}
+
 // ── chain address helpers ─────────────────────────────────────────────────────
 
 fn evm_address(env: &Env) -> Bytes {


### PR DESCRIPTION
## Summary

Closes #298

Setting the same SMT root twice wastes fees and emits a `ROOT_UPD` event with identical before/after values. Added a guard that panics with `RootUnchanged` (#11) if `new_root == current_root`.

## Changes

- `core_contract/src/errors.rs`: Added `RootUnchanged = 11` to `CoreError`
- `core_contract/src/admin.rs`: Added guard in `update_smt_root` before calling `SmtRoot::update_root`
- `core_contract/src/test.rs`: Added `test_update_smt_root_same_root_fails`

## Verification

- `cargo test -p core_contract` — 67 passed ✅
- `cargo clippy -p core_contract -- -D warnings` — clean ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * SMT root updates are now rejected when the new root matches the current stored root, with clear error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->