### PR TITLE
Feat/setupautopay should reject from  to self payment

### DIFF
--- a/gateway-contract/contracts/escrow_contract/src/errors.rs
+++ b/gateway-contract/contracts/escrow_contract/src/errors.rs
@@ -36,4 +36,6 @@ pub enum EscrowError {
     VaultAlreadyExists = 15,
     /// The contract has already been initialized.
     AlreadyInitialized = 16,
+    /// Self-payment is not allowed (from == to).
+    SelfPaymentNotAllowed = 17,
 }

--- a/gateway-contract/contracts/escrow_contract/src/lib.rs
+++ b/gateway-contract/contracts/escrow_contract/src/lib.rs
@@ -388,7 +388,12 @@ impl EscrowContract {
             return Err(EscrowError::InvalidInterval);
         }
 
-        // 2. Read Vault config to verify it exists and get the token
+        // 2. Reject self-payment
+        if from == to {
+            return Err(EscrowError::SelfPaymentNotAllowed);
+        }
+
+        // 3. Read Vault config to verify it exists and get the token
         let config = read_vault_config(&env, &from).ok_or(EscrowError::VaultNotFound)?;
 
         // 3. Authenticate caller as owner of from vault

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -965,3 +965,22 @@ fn test_initialize_twice_returns_already_initialized() {
         Err(Ok(err)) if err == Error::from_contract_error(EscrowError::AlreadyInitialized as u32)
     ));
 }
+
+// ─── auto-pay self-payment test ──────────────────────────────────────────────
+
+#[test]
+fn test_auto_pay_self_payment_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, token, _token_admin, from, _to) = setup_test(&env);
+
+    let owner = Address::generate(&env);
+    create_vault(&env, &contract_id, &from, &owner, &token, 1000);
+
+    // Attempt to setup auto-pay with from == to (self-payment)
+    let result = client.try_setup_auto_pay(&from, &from, &100, &86400);
+    assert!(matches!(
+        result,
+        Err(Ok(err)) if err == Error::from_contract_error(EscrowError::SelfPaymentNotAllowed as u32)
+    ));
+}


### PR DESCRIPTION
Closes #293

## 🛡️ Fix: Reject Self-Payment in `setup_auto_pay`

Adds a guard to prevent a vault from auto-paying itself by rejecting calls where `from == to`.

### Changes

**`gateway-contract/contracts/escrow_contract/src/lib.rs`**
- Added self-payment guard in `setup_auto_pay` — panics with `SelfPaymentNotAllowed` (or `InvalidAmount`) when `from == to`

**`gateway-contract/contracts/escrow_contract/src/test.rs`**
- Added `test_auto_pay_self_payment_fails` verifying the guard rejects self-payment correctly

### Checklist
- ✅ Guard added for `from == to` case
- ✅ Test added covering the new behaviour
- ✅ `cargo test` and `cargo clippy` pass with no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Escrow contract now rejects self-payments in auto-pay setup when sender and recipient are identical.

* **Tests**
  * Added unit tests for auto-pay validation and contract initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->