### PR TITLE
feat: alien-gateway add get_created_at read-only query

### DIFF
--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -62,6 +62,9 @@ impl Contract {
     /// Gets the owner of a commitment. See [registration::Registration::get_owner].
     pub fn get_owner(e: Env, h: BytesN<32>) -> Option<Address> { Registration::get_owner(e, h) }
 
+    /// Gets the registration ledger timestamp for a commitment. See [registration::Registration::get_created_at].
+    pub fn get_created_at(e: Env, h: BytesN<32>) -> Option<u64> { Registration::get_created_at(e, h) }
+
     /// Adds a blockchain address for a commitment. See [address_manager::AddressManager::add_chain_address].
     pub fn add_chain_address(e: Env, c: Address, h: BytesN<32>, t: ChainType, a: Bytes) { AddressManager::add_chain_address(e, c, h, t, a); }
 

--- a/gateway-contract/contracts/core_contract/src/registration.rs
+++ b/gateway-contract/contracts/core_contract/src/registration.rs
@@ -1,6 +1,6 @@
 use crate::errors::CoreError;
 use crate::events::REGISTER_EVENT;
-use crate::storage::{PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
+use crate::storage::{self, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
 use soroban_sdk::{contracttype, panic_with_error, Address, BytesN, Env};
 
 // Storage Keys
@@ -47,6 +47,9 @@ impl Registration {
             PERSISTENT_BUMP_AMOUNT,
         );
 
+        // Store registration timestamp
+        storage::set_created_at(&env, &commitment, env.ledger().timestamp());
+
         // Emit registration event
         #[allow(deprecated)]
         env.events()
@@ -68,5 +71,21 @@ impl Registration {
     pub fn get_owner(env: Env, commitment: BytesN<32>) -> Option<Address> {
         let key = DataKey::Commitment(commitment);
         env.storage().persistent().get(&key)
+    }
+
+    /// Retrieves the ledger timestamp at which a commitment was first registered.
+    ///
+    /// Returns the Unix timestamp (seconds) recorded at registration time, or None if the
+    /// commitment has never been registered.
+    ///
+    /// ### Arguments
+    /// - `env`: The Soroban contract environment.
+    /// - `commitment`: The 32-byte username commitment to look up.
+    ///
+    /// ### Returns
+    /// - `Some(u64)` with the registration ledger timestamp.
+    /// - `None` if the commitment is not found.
+    pub fn get_created_at(env: Env, commitment: BytesN<32>) -> Option<u64> {
+        storage::get_created_at(&env, &commitment)
     }
 }

--- a/gateway-contract/contracts/core_contract/src/storage.rs
+++ b/gateway-contract/contracts/core_contract/src/storage.rs
@@ -24,6 +24,8 @@ pub enum DataKey {
     Owner,
     /// Key for a shielded address commitment, indexed by username hash.
     ShieldedAddress(BytesN<32>),
+    /// Key for the ledger timestamp at which a commitment was first registered.
+    CreatedAt(BytesN<32>),
 }
 
 pub fn set_privacy_mode(env: &Env, username_hash: &BytesN<32>, mode: &PrivacyMode) {
@@ -75,4 +77,20 @@ pub fn has_shielded_address(env: &Env, username_hash: &BytesN<32>) -> bool {
     env.storage()
         .persistent()
         .has(&DataKey::ShieldedAddress(username_hash.clone()))
+}
+
+pub fn set_created_at(env: &Env, username_hash: &BytesN<32>, timestamp: u64) {
+    let key = DataKey::CreatedAt(username_hash.clone());
+    env.storage().persistent().set(&key, &timestamp);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+pub fn get_created_at(env: &Env, username_hash: &BytesN<32>) -> Option<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CreatedAt(username_hash.clone()))
 }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -7,7 +7,7 @@ use crate::{Contract, ContractClient};
 use escrow_contract::types::{
     AutoPay, ScheduledPayment as EscrowScheduledPayment, VaultConfig, VaultState,
 };
-use soroban_sdk::testutils::{Address as _, Events, MockAuth, MockAuthInvoke};
+use soroban_sdk::testutils::{Address as _, Events, Ledger as _, MockAuth, MockAuthInvoke};
 use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, IntoVal, Symbol, Val, Vec};
 
 fn setup(env: &Env) -> (Address, ContractClient<'_>) {

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -1287,3 +1287,69 @@ fn test_add_shielded_address_unregistered_panics() {
     let result = client.try_add_shielded_address(&caller, &hash, &addr_commitment);
     assert!(result.is_err());
 }
+
+// ============================================================================
+// get_created_at tests
+// ============================================================================
+
+#[test]
+fn test_get_created_at_returns_none_for_unregistered() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let hash = commitment(&env, 90);
+    assert_eq!(client.get_created_at(&hash), None);
+}
+
+#[test]
+fn test_get_created_at_returns_timestamp_after_register() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 91);
+
+    client.register(&owner, &hash);
+
+    // The default test env ledger timestamp is 0
+    assert_eq!(client.get_created_at(&hash), Some(0u64));
+}
+
+#[test]
+fn test_get_created_at_reflects_ledger_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    env.ledger().set_timestamp(1_700_000_000);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 92);
+
+    client.register(&owner, &hash);
+
+    assert_eq!(client.get_created_at(&hash), Some(1_700_000_000u64));
+}
+
+#[test]
+fn test_get_created_at_unchanged_after_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    env.ledger().set_timestamp(1_000_000);
+
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let hash = commitment(&env, 93);
+
+    client.register(&owner, &hash);
+    assert_eq!(client.get_created_at(&hash), Some(1_000_000u64));
+
+    // Advance time and transfer — created_at must remain the original timestamp
+    env.ledger().set_timestamp(2_000_000);
+    client.transfer_ownership(&owner, &hash, &new_owner);
+
+    assert_eq!(client.get_created_at(&hash), Some(1_000_000u64));
+}


### PR DESCRIPTION
Closes #304

---

Added a get_created_at read-only query to the core contract that returns the ledger timestamp at which a username commitment was first registered.

How
Added CreatedAt(BytesN<32>) key to DataKey in storage.rs with set_created_at / get_created_at helpers following the existing TTL bump pattern
Updated register() in registration.rs to store env.ledger().timestamp() atomically at registration time
Added get_created_at method to Registration and exposed it as a public contract entry point in lib.rs
Added 4 tests in test.rs covering: unregistered returns None, default timestamp, custom ledger timestamp, and timestamp unchanged after ownership transfer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added creation timestamp tracking for commitments: the contract records the ledger timestamp when a commitment is registered and exposes a query to retrieve that registration timestamp.
* **Tests**
  * Added unit tests covering retrieval for unregistered commitments, timestamp recording on register, explicit timestamp values, and preservation across ownership transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->