### PR TITLE
docs: add formula comments to TTL constants in auction storage

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -2,10 +2,10 @@ use crate::types::{AuctionStatus, DataKey};
 use soroban_sdk::{Address, Env};
 
 /// TTL constants for persistent storage entries.
-/// Bump amount: ~30 days (at ~5s per ledger close).
-pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
-/// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
-pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
+/// PERSISTENT_BUMP_AMOUNT: 30 days × 24h × 3600s / 5s per ledger = 518_400 ledgers
+pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400; // 30 * 24 * 3600 / 5
+/// PERSISTENT_LIFETIME_THRESHOLD: 7 days × 24h × 3600s / 5s per ledger = 120_960 ledgers
+pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960; // 7 * 24 * 3600 / 5
 
 pub fn get_status(env: &Env) -> AuctionStatus {
     env.storage()

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -14,6 +14,16 @@ impl DummyFactory {
     pub fn deploy_username(_env: Env, _username_hash: BytesN<32>, _claimer: Address) {}
 }
 
+// ── TTL constant sanity checks ────────────────────────────────────────────────
+
+#[test]
+fn test_ttl_constants_match_formula() {
+    // 30 days * 24h * 3600s / 5s per ledger = 518_400
+    assert_eq!(storage::PERSISTENT_BUMP_AMOUNT, 30 * 24 * 3600 / 5);
+    // 7 days * 24h * 3600s / 5s per ledger = 120_960
+    assert_eq!(storage::PERSISTENT_LIFETIME_THRESHOLD, 7 * 24 * 3600 / 5);
+}
+
 // ── existing tests ────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
---

**Title:** `docs: add formula comments to TTL constants in auction storage`

**Body:**
Closes #266
```
## Summary

PERSISTENT_BUMP_AMOUNT and PERSISTENT_LIFETIME_THRESHOLD in
`auction_contract/src/storage.rs` were defined as raw numbers with
vague prose comments. This PR replaces them with explicit inline
formula comments so the derivation is immediately clear to any reader.

## Changes

**storage.rs**
- Updated doc comments on both constants to include the full formula:
  - `30 * 24 * 3600 / 5 = 518_400` (30 days at ~5s per ledger)
  - `7 * 24 * 3600 / 5 = 120_960` (7-day lifetime threshold)
- Added trailing inline `// formula` comments on the const lines

**test.rs**
- Added `test_ttl_constants_match_formula` which asserts both constants
  equal their formula expression, so any future value drift is caught
  at test time.

## Verification

- `cargo test -p auction_contract` — 20/20 passed
- `cargo clippy -p auction_contract -- -D warnings` — no warnings

Closes #266
```

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for persistent storage time-to-live constants with clarified computation details.

* **Tests**
  * Added validation test for persistent storage time-to-live constants to ensure values match expected formulas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->