### PR TITLE
refactor(factory): move factory DataKey enum to types.rs

### DIFF
--- a/gateway-contract/contracts/factory_contract/src/storage.rs
+++ b/gateway-contract/contracts/factory_contract/src/storage.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::{contracttype, Address, BytesN, Env};
+use soroban_sdk::{Address, BytesN, Env};
 
-use crate::types::{DeployConfig, UsernameRecord};
+use crate::types::{DataKey, DeployConfig, UsernameRecord};
 
 /// TTL constants for persistent storage entries.
 /// Bump amount: ~30 days (at ~5s per ledger close).
@@ -8,19 +8,6 @@ pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
 /// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 
-/// Storage keys used by the factory contract.
-#[contracttype]
-#[derive(Clone)]
-pub enum DataKey {
-    /// Address of the auction contract authorised to deploy usernames.
-    AuctionContract,
-    /// Address of the core contract associated with new usernames.
-    CoreContract,
-    /// Record for a registered username, keyed by its 32-byte hash.
-    Username(BytesN<32>),
-    /// Optional deployment configuration for the factory.
-    Config,
-}
 
 /// Persists the auction contract address in instance storage.
 pub fn set_auction_contract(env: &Env, auction_contract: &Address) {

--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -1,9 +1,10 @@
-use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger, MockAuth, MockAuthInvoke};
+use soroban_sdk::testutils::storage::Persistent as _;
 use soroban_sdk::{contract, contractimpl, IntoVal, Symbol, TryFromVal, Val, Vec};
 use soroban_sdk::{Address, BytesN, Env};
 
 use crate::errors::FactoryError;
-use crate::events::{OWNERSHIP_TRANSFERRED, USERNAME_DEPLOYED};
+use crate::events::USERNAME_DEPLOYED;
 use crate::{FactoryContract, FactoryContractClient};
 
 #[contract]
@@ -273,7 +274,8 @@ fn test_get_owner_none_for_unknown() {
 
 #[test]
 fn get_username_record_extends_ttl_on_read() {
-    use crate::storage::{DataKey, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
+    use crate::storage::{PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
+    use crate::types::DataKey;
 
     let env = Env::default();
     let (factory_id, factory, auction_contract, _) = setup_factory(&env);

--- a/gateway-contract/contracts/factory_contract/src/types.rs
+++ b/gateway-contract/contracts/factory_contract/src/types.rs
@@ -1,5 +1,19 @@
 use soroban_sdk::{contracttype, Address, BytesN};
 
+/// Storage keys used by the factory contract.
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Address of the auction contract authorised to deploy usernames.
+    AuctionContract,
+    /// Address of the core contract associated with new usernames.
+    CoreContract,
+    /// Record for a registered username, keyed by its 32-byte hash.
+    Username(BytesN<32>),
+    /// Optional deployment configuration for the factory.
+    Config,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// On-chain record for a registered username.

--- a/gateway-contract/contracts/factory_contract/test_snapshots/test/test_deploy_username_duplicate_fails.1.json
+++ b/gateway-contract/contracts/factory_contract/test_snapshots/test/test_deploy_username_duplicate_fails.1.json
@@ -1,7 +1,7 @@
 {
   "generators": {
     "address": 4,
-    "nonce": 2,
+    "nonce": 1,
     "mux_id": 0
   },
   "auth": [
@@ -32,7 +32,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {


### PR DESCRIPTION
Move the enum and update imports in storage.rs

closes #277 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal storage code structure to improve maintainability and clarity. Updated corresponding tests to align with the restructured modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->