### PR TITLE
feat: add is_vault_active query to escrow

### DIFF
--- a/gateway-contract/contracts/escrow_contract/src/lib.rs
+++ b/gateway-contract/contracts/escrow_contract/src/lib.rs
@@ -14,9 +14,10 @@ mod test;
 use crate::errors::EscrowError;
 use crate::events::Events;
 use crate::storage::{
-    increment_auto_pay_id, increment_payment_id, read_auto_pay, read_auto_pay_count,
-    read_registration_contract, read_vault_config, read_vault_state, write_auto_pay,
-    write_registration_contract, write_scheduled_payment, write_vault_config, write_vault_state,
+    delete_auto_pay, increment_auto_pay_id, increment_payment_id, read_auto_pay,
+    read_auto_pay_count, read_registration_contract, read_vault_config, read_vault_state,
+    write_auto_pay, write_registration_contract, write_scheduled_payment, write_vault_config,
+    write_vault_state,
 };
 use crate::types::{AutoPay, DataKey, ScheduledPayment, VaultConfig, VaultState};
 use soroban_sdk::{
@@ -621,6 +622,23 @@ impl EscrowContract {
     pub fn get_scheduled_payment(env: Env, payment_id: u32) -> Option<ScheduledPayment> {
         let key = DataKey::ScheduledPayment(payment_id);
         env.storage().persistent().get(&key)
+    }
+
+    /// Returns the active status of a vault identified by its commitment.
+    ///
+    /// This three-way query disambiguates the case of a cancelled-but-empty vault
+    /// from a commitment that was never registered — something a plain balance
+    /// check or storage `has()` call cannot do.
+    ///
+    /// ### Arguments
+    /// - `commitment`: The `BytesN<32>` identity commitment of the vault.
+    ///
+    /// ### Returns
+    /// - `None`         — no vault has ever been created for this commitment.
+    /// - `Some(true)`   — the vault exists and is currently active.
+    /// - `Some(false)`  — the vault exists but has been cancelled.
+    pub fn is_vault_active(env: Env, commitment: BytesN<32>) -> Option<bool> {
+        read_vault_state(&env, &commitment).map(|state| state.is_active)
     }
 }
 

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -1702,3 +1702,79 @@ fn test_cancel_auto_pay_vault_not_found() {
         result
     );
 }
+
+// ─── is_vault_active tests ────────────────────────────────────────────────────
+
+/// A vault that has been created (and not cancelled) must return `Some(true)`.
+///
+/// This is the primary happy-path: the commitment exists in storage and
+/// `is_active` is `true`.
+#[test]
+fn test_is_vault_active_returns_some_true_for_active_vault() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, token, _, from, _) = setup_test(&env);
+
+    create_vault(
+        &env,
+        &contract_id,
+        &from,
+        &Address::generate(&env),
+        &token,
+        0,
+    );
+
+    assert_eq!(
+        client.is_vault_active(&from),
+        Some(true),
+        "active vault must return Some(true)"
+    );
+}
+
+/// A vault that has been cancelled must return `Some(false)`.
+///
+/// This proves the query distinguishes a cancelled vault from one that
+/// was never created — the whole point of this three-way return type.
+#[test]
+fn test_is_vault_active_returns_some_false_for_cancelled_vault() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, token, _, from, _) = setup_test(&env);
+
+    create_vault(
+        &env,
+        &contract_id,
+        &from,
+        &Address::generate(&env),
+        &token,
+        0,
+    );
+
+    // Cancel the vault so is_active becomes false.
+    client.cancel_vault(&from);
+
+    assert_eq!(
+        client.is_vault_active(&from),
+        Some(false),
+        "cancelled vault must return Some(false)"
+    );
+}
+
+/// A commitment that was never deposited into must return `None`.
+///
+/// This covers the "vault does not exist" branch: no `VaultState` record
+/// exists in storage, so the function must return `None` rather than panic.
+#[test]
+fn test_is_vault_active_returns_none_for_nonexistent_vault() {
+    let env = Env::default();
+    let (_, client, _, _, _, _) = setup_test(&env);
+
+    // Use a commitment seed that was never passed to create_vault.
+    let nonexistent = BytesN::from_array(&env, &[0xDEu8; 32]);
+
+    assert_eq!(
+        client.is_vault_active(&nonexistent),
+        None,
+        "nonexistent vault must return None"
+    );
+}


### PR DESCRIPTION
## feat: add `is_vault_active` query to escrow

Closes #288

### Problem

The existing storage `.has()` check on a vault commitment cannot distinguish between a vault that was **cancelled** and one that **never existed** — both return `false`. This makes it impossible for callers to reason about vault state without additional context.

### Solution

Added a new read-only `is_vault_active` query function to the escrow contract that returns `Option<bool>`, giving callers a proper three-way result:

| Return value | Meaning |
|---|---|
| `Some(true)` | Vault exists and is active |
| `Some(false)` | Vault exists but has been cancelled |
| `None` | Commitment has never been registered |

### Changes

**`contracts/escrow_contract/src/lib.rs`**
- Added `is_vault_active(env: Env, commitment: BytesN<32>) -> Option<bool>` to the `#[contractimpl]` block
- Reuses the existing `read_vault_state` helper — no new storage logic introduced
- Added `delete_auto_pay` to storage imports (was called in `cancel_auto_pay` but missing from the `use` statement)

**`contracts/escrow_contract/src/test.rs`**
- Added three test cases covering all return variants:
  - `test_is_vault_active_returns_true` — active vault returns `Some(true)`
  - `test_is_vault_active_returns_false_after_cancel` — cancelled vault returns `Some(false)`
  - `test_is_vault_active_returns_none_for_nonexistent` — unknown commitment returns `None`

### Testing

```
cargo clippy --all-targets -- -D warnings
cargo test
```

All tests pass, no new warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a query to check the active status of vaults, supporting both existing and non-existent vaults.

* **Tests**
  * Added unit tests covering three scenarios: active vaults, cancelled vaults, and vaults that have not been created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->