### PR TITLE
refactor: rename factory get_auction_contract / get_core_contract to d

### DIFF
--- a/gateway-contract/contracts/factory_contract/factory.md
+++ b/gateway-contract/contracts/factory_contract/factory.md
@@ -132,14 +132,14 @@ None.
 
 ---
 
-## Function: `get_auction_contract`
+## Function: `auction_contract`
 
 Returns the auction contract address stored during `configure`, or `None` if not yet configured.
 
 ### Interface
 
 ```rust
-pub fn get_auction_contract(env: Env) -> Option<Address>
+pub fn auction_contract(env: Env) -> Option<Address>
 ```
 
 ### Requirements & Validation
@@ -156,14 +156,14 @@ None.
 
 ---
 
-## Function: `get_core_contract`
+## Function: `core_contract`
 
 Returns the core resolver contract address stored during `configure`, or `None` if not yet configured.
 
 ### Interface
 
 ```rust
-pub fn get_core_contract(env: Env) -> Option<Address>
+pub fn core_contract(env: Env) -> Option<Address>
 ```
 
 ### Requirements & Validation

--- a/gateway-contract/contracts/factory_contract/src/lib.rs
+++ b/gateway-contract/contracts/factory_contract/src/lib.rs
@@ -17,8 +17,8 @@ use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env
 use crate::errors::FactoryError;
 use crate::events::{emit_ownership_transferred, emit_username_deployed};
 use crate::storage::{
-    get_auction_contract, get_core_contract, get_username, has_username, set_auction_contract,
-    set_core_contract, set_username,
+    get_auction_contract as read_auction_contract, get_core_contract as read_core_contract,
+    get_username, has_username, set_auction_contract, set_core_contract, set_username,
 };
 use crate::types::UsernameRecord;
 
@@ -66,7 +66,7 @@ impl FactoryContract {
     ///
     /// O(1) - constant time storage lookups and persistence.
     pub fn deploy_username(env: Env, username_hash: BytesN<32>, owner: Address) {
-        let auction_contract = match get_auction_contract(&env) {
+        let auction_contract = match read_auction_contract(&env) {
             Some(address) => address,
             None => panic_with_error!(&env, FactoryError::Unauthorized),
         };
@@ -76,7 +76,7 @@ impl FactoryContract {
             panic_with_error!(&env, FactoryError::AlreadyDeployed);
         }
 
-        let core_contract = match get_core_contract(&env) {
+        let core_contract = match read_core_contract(&env) {
             Some(address) => address,
             None => panic_with_error!(&env, FactoryError::CoreContractNotConfigured),
         };
@@ -107,7 +107,7 @@ impl FactoryContract {
     /// * `username_hash` - The 32-byte hash identifying the unique username.
     /// * `new_owner` - The address that will be the new owner.
     pub fn transfer_username(env: Env, username_hash: BytesN<32>, new_owner: Address) {
-        let auction_contract = match get_auction_contract(&env) {
+        let auction_contract = match read_auction_contract(&env) {
             Some(address) => address,
             None => panic_with_error!(&env, FactoryError::Unauthorized),
         };
@@ -177,8 +177,8 @@ impl FactoryContract {
     ///
     /// * `Some(Address)` if configured.
     /// * `None` otherwise.
-    pub fn get_auction_contract(env: Env) -> Option<Address> {
-        get_auction_contract(&env)
+    pub fn auction_contract(env: Env) -> Option<Address> {
+        read_auction_contract(&env)
     }
 
     /// Retrieves the currently configured core contract address.
@@ -191,7 +191,7 @@ impl FactoryContract {
     ///
     /// * `Some(Address)` if configured.
     /// * `None` otherwise.
-    pub fn get_core_contract(env: Env) -> Option<Address> {
-        get_core_contract(&env)
+    pub fn core_contract(env: Env) -> Option<Address> {
+        read_core_contract(&env)
     }
 }

--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -1,9 +1,11 @@
-use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::testutils::{
+    storage::Persistent, Address as _, Events as _, Ledger as _, MockAuth, MockAuthInvoke,
+};
 use soroban_sdk::{contract, contractimpl, IntoVal, Symbol, TryFromVal, Val, Vec};
 use soroban_sdk::{Address, BytesN, Env};
 
 use crate::errors::FactoryError;
-use crate::events::{OWNERSHIP_TRANSFERRED, USERNAME_DEPLOYED};
+use crate::events::USERNAME_DEPLOYED;
 use crate::{FactoryContract, FactoryContractClient};
 
 #[contract]
@@ -21,6 +23,12 @@ fn setup_factory(env: &Env) -> (Address, FactoryContractClient<'_>, Address, Add
     factory.configure(&auction_contract, &core_contract);
 
     (factory_id, factory, auction_contract, core_contract)
+}
+
+fn setup_unconfigured_factory(env: &Env) -> (Address, FactoryContractClient<'_>) {
+    let factory_id = env.register(FactoryContract, ());
+    let factory = FactoryContractClient::new(env, &factory_id);
+    (factory_id, factory)
 }
 
 fn username_hash(env: &Env) -> BytesN<32> {
@@ -52,20 +60,27 @@ fn deploy_username_stores_record_and_emits_event() {
 
     let events = env.events().all();
 
-    let record = factory.get_username_record(&hash).unwrap();
+    let record = factory
+        .get_username_record(&hash)
+        .expect("username record should be stored after deploy");
     assert_eq!(record.username_hash, hash);
     assert_eq!(record.owner, owner);
     assert_eq!(record.registered_at, env.ledger().timestamp());
     assert_eq!(record.core_contract, core_contract);
     assert_eq!(events.len(), 1);
 
-    let (event_contract, topics, data) = events.get(0).unwrap();
+    let (event_contract, topics, data) = events.get(0).expect("expected exactly one event");
     assert_eq!(event_contract, factory_id);
     assert_eq!(topics.len(), 1);
 
-    let event_name = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+    let event_name = Symbol::try_from_val(
+        &env,
+        &topics.get(0).expect("expected event name topic"),
+    )
+    .expect("event name should deserialize");
     let (event_hash, event_owner, event_registered_at) =
-        <(BytesN<32>, Address, u64)>::try_from_val(&env, &data).unwrap();
+        <(BytesN<32>, Address, u64)>::try_from_val(&env, &data)
+            .expect("event payload should deserialize");
 
     assert_eq!(event_name, USERNAME_DEPLOYED);
     assert_eq!(event_hash, hash);
@@ -195,7 +210,9 @@ fn test_deploy_username_success() {
     }]);
 
     factory.deploy_username(&hash, &owner);
-    let record = factory.get_username_record(&hash).unwrap();
+    let record = factory
+        .get_username_record(&hash)
+        .expect("username record should be stored after deploy");
     assert_eq!(record.owner, owner);
 }
 
@@ -218,7 +235,15 @@ fn test_deploy_username_duplicate_fails() {
     }]);
     factory.deploy_username(&hash, &owner);
 
-    // Do not re-mock auth here: the previous successful auth context is still valid for the next invocation
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "deploy_username",
+            args: deploy_args,
+            sub_invokes: &[],
+        },
+    }]);
     let result = env.try_invoke_contract::<(), FactoryError>(
         &factory_id,
         &Symbol::new(&env, "deploy_username"),
@@ -294,7 +319,7 @@ fn get_username_record_extends_ttl_on_read() {
 
     // Advance the ledger so the remaining TTL drops below the lifetime threshold.
     env.ledger().with_mut(|l| {
-        l.sequence_number += (PERSISTENT_BUMP_AMOUNT - PERSISTENT_LIFETIME_THRESHOLD + 1) as u32;
+        l.sequence_number += PERSISTENT_BUMP_AMOUNT - PERSISTENT_LIFETIME_THRESHOLD + 1;
     });
 
     // Reading the record should bump the TTL back to PERSISTENT_BUMP_AMOUNT.
@@ -308,4 +333,16 @@ fn get_username_record_extends_ttl_on_read() {
             .get_ttl(&DataKey::Username(hash.clone()));
         assert_eq!(ttl, PERSISTENT_BUMP_AMOUNT);
     });
+}
+
+#[test]
+fn contract_getters_follow_soroban_convention() {
+    let env = Env::default();
+    let (_, factory) = setup_unconfigured_factory(&env);
+    assert_eq!(factory.auction_contract(), None);
+    assert_eq!(factory.core_contract(), None);
+
+    let (_, factory, auction_contract, core_contract) = setup_factory(&env);
+    assert_eq!(factory.auction_contract(), Some(auction_contract));
+    assert_eq!(factory.core_contract(), Some(core_contract));
 }


### PR DESCRIPTION
 Description

Soroban convention prefers auction_contract() over get_auction_contract(). Rename both getters and update all call-sites. All tests must pass.

Close #275 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed public getter APIs for naming consistency; behavior and returned values remain unchanged.

* **Tests**
  * Improved test coverage and assertions, including explicit checks for getter behavior before and after configuration and clearer failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->