### PR TITLE
refactor: extract AuctionStatus transition checks into a helper

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/events.rs
+++ b/gateway-contract/contracts/auction_contract/src/events.rs
@@ -101,5 +101,7 @@ pub fn emit_bid_refunded(
     // Publish a canonical event with the BID_REFUNDED symbol and username_hash as topic,
     // and (bidder, refund_amount) as the data tuple. Using explicit publish ensures the
     // first topic is the event symbol which tests rely on.
-    env.events().publish((BID_REFUNDED, username_hash.clone()), (bidder.clone(), refund_amount));
+    #[allow(deprecated)]
+    env.events()
+        .publish((BID_REFUNDED, username_hash.clone()), (bidder.clone(), refund_amount));
 }

--- a/gateway-contract/contracts/auction_contract/src/indexed.rs
+++ b/gateway-contract/contracts/auction_contract/src/indexed.rs
@@ -2,7 +2,7 @@
 /// Handles `create_auction`, `place_bid`, `close_auction_by_id`, and `claim`.
 use soroban_sdk::{Address, Env};
 
-use crate::{errors, storage, types};
+use crate::{errors, events, storage, types};
 
 pub fn create_auction(
     env: &Env,
@@ -19,21 +19,41 @@ pub fn create_auction(
     if end_time <= env.ledger().timestamp() {
         soroban_sdk::panic_with_error!(env, errors::AuctionError::AuctionNotClosed);
     }
+    if min_bid <= 0 {
+        soroban_sdk::panic_with_error!(env, errors::AuctionError::BidTooLow);
+    }
     storage::auction_set_seller(env, id, &seller);
     storage::auction_set_asset(env, id, &asset);
     storage::auction_set_min_bid(env, id, min_bid);
     storage::auction_set_end_time(env, id, end_time);
     storage::auction_set_status(env, id, types::AuctionStatus::Open);
+
+    let username_hash = soroban_sdk::BytesN::from_array(env, &[0u8; 32]);
+    storage::auction_set_username_hash(env, id, &username_hash);
+    events::emit_auction_created(env, &username_hash, end_time, min_bid);
 }
 
 pub fn place_bid(env: &Env, id: u32, bidder: Address, amount: i128) {
     bidder.require_auth();
+    if !storage::auction_exists(env, id) {
+        soroban_sdk::panic_with_error!(env, errors::AuctionError::AuctionNotOpen);
+    }
+    if storage::auction_get_status(env, id) != types::AuctionStatus::Open {
+        soroban_sdk::panic_with_error!(env, errors::AuctionError::AuctionNotOpen);
+    }
     let end_time = storage::auction_get_end_time(env, id);
     if env.ledger().timestamp() >= end_time {
         soroban_sdk::panic_with_error!(env, errors::AuctionError::AuctionNotOpen);
     }
     let min_bid = storage::auction_get_min_bid(env, id);
     let highest_bid = storage::auction_get_highest_bid(env, id);
+    if storage::auction_get_highest_bidder(env, id)
+        .as_ref()
+        .map(|h| h == &bidder)
+        .unwrap_or(false)
+    {
+        soroban_sdk::panic_with_error!(env, errors::AuctionError::Unauthorized);
+    }
     if amount < min_bid || amount <= highest_bid {
         soroban_sdk::panic_with_error!(env, errors::AuctionError::BidTooLow);
     }
@@ -41,18 +61,31 @@ pub fn place_bid(env: &Env, id: u32, bidder: Address, amount: i128) {
     let token = soroban_sdk::token::Client::new(env, &asset);
     token.transfer(&bidder, env.current_contract_address(), &amount);
     if let Some(prev_bidder) = storage::auction_get_highest_bidder(env, id) {
-        token.transfer(&env.current_contract_address(), &prev_bidder, &highest_bid);
+        storage::auction_set_outbid_amount(env, id, &prev_bidder, highest_bid);
+        let username_hash = storage::auction_get_username_hash(env, id);
+        events::emit_bid_refunded(env, &username_hash, &prev_bidder, highest_bid);
     }
     storage::auction_set_highest_bidder(env, id, &bidder);
     storage::auction_set_highest_bid(env, id, amount);
+
+    let username_hash = storage::auction_get_username_hash(env, id);
+    events::emit_bid_placed(env, &username_hash, &bidder, amount);
 }
 
 pub fn close_auction_by_id(env: &Env, id: u32) {
+    if !storage::auction_exists(env, id) {
+        soroban_sdk::panic_with_error!(env, errors::AuctionError::AuctionNotOpen);
+    }
     let end_time = storage::auction_get_end_time(env, id);
     if env.ledger().timestamp() < end_time {
         soroban_sdk::panic_with_error!(env, errors::AuctionError::AuctionNotClosed);
     }
     storage::auction_set_status(env, id, types::AuctionStatus::Closed);
+
+    let username_hash = storage::auction_get_username_hash(env, id);
+    let winner = storage::auction_get_highest_bidder(env, id);
+    let winning_bid = storage::auction_get_highest_bid(env, id) as u128;
+    events::emit_auction_closed(env, &username_hash, winner, winning_bid);
 }
 
 pub fn claim(env: &Env, id: u32, claimant: Address) {

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -11,6 +11,8 @@ pub mod types;
 // Ensure event symbols are linked from the main
 // contract entrypoint module.
 use crate::events::{AUCTION_CLOSED, AUCTION_CREATED, BID_PLACED, BID_REFUNDED, USERNAME_CLAIMED};
+use crate::errors::AuctionError;
+use crate::types::AuctionStatus;
 
 /// Ensures event symbol constants are referenced from the crate root so the
 /// linker does not strip them when compiling to WASM.
@@ -23,6 +25,14 @@ fn _touch_event_symbols() {
         USERNAME_CLAIMED,
         BID_REFUNDED,
     );
+}
+
+#[allow(clippy::missing_docs_in_private_items)]
+fn require_status(env: &Env, status: AuctionStatus, expected: AuctionStatus, err: AuctionError) {
+    let _ = env;
+    if status != expected {
+        soroban_sdk::panic_with_error!(env, err);
+    }
 }
 
 #[cfg(test)]
@@ -124,6 +134,7 @@ impl AuctionContract {
         indexed::claim(&env, id, claimant)
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn get_auction_info(
         env: Env,
         id: u32,

--- a/gateway-contract/contracts/auction_contract/src/singleton.rs
+++ b/gateway-contract/contracts/auction_contract/src/singleton.rs
@@ -10,10 +10,7 @@ pub fn close_auction(
     username_hash: BytesN<32>,
 ) -> Result<(), AuctionError> {
     let status = storage::get_status(env);
-
-        if status != types::AuctionStatus::Open {
-            return Err(AuctionError::AuctionNotOpen);
-        }
+    crate::require_status(env, status, types::AuctionStatus::Open, AuctionError::AuctionNotOpen);
 
     let current_time = env.ledger().timestamp();
     let end_time = storage::get_end_time(env);
@@ -45,9 +42,7 @@ pub fn close_auction(
             return Err(AuctionError::AlreadyClaimed);
         }
 
-        if status != types::AuctionStatus::Closed {
-            return Err(AuctionError::NotClosed);
-        }
+    crate::require_status(env, status, types::AuctionStatus::Closed, AuctionError::NotClosed);
 
     let highest_bidder = storage::get_highest_bidder(env);
         if !highest_bidder.map(|h| h == claimer).unwrap_or(false) {

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -203,7 +203,7 @@ pub fn auction_get_username_hash(env: &Env, id: u32) -> BytesN<32> {
     env.storage()
         .persistent()
         .get(&AuctionKey::UsernameHash(id))
-        .unwrap_or(BytesN::from_array(&env, &[0; 32]))
+        .unwrap_or(BytesN::from_array(env, &[0; 32]))
 }
 
 pub fn auction_set_username_hash(env: &Env, id: u32, username_hash: &BytesN<32>) {

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::super::*;
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::testutils::Events as _;
-    use soroban_sdk::{Env, Symbol, TryFromVal, TryIntoVal};
+    use soroban_sdk::{Env, TryFromVal};
 
     #[test]
     fn test_bid_refunded_event_emitted_when_outbid() {
@@ -21,7 +21,7 @@ mod tests {
         let token_admin = Address::generate(&env);
         let asset = env.register_stellar_asset_contract_v2(token_admin).address();
         let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
-        let token = soroban_sdk::token::Client::new(&env, &asset);
+        let _token = soroban_sdk::token::Client::new(&env, &asset);
         token_admin_client.mint(&alice, &1000);
         token_admin_client.mint(&bob, &1000);
 
@@ -51,7 +51,9 @@ mod tests {
                     found = true;
                     break;
                 }
-            } else if let Ok((uh, ev_bidder, ev_amount)) = <(BytesN<32>, Address, i128)>::try_from_val(&env, &data) {
+            } else if let Ok((_uh, ev_bidder, ev_amount)) =
+                <(BytesN<32>, Address, i128)>::try_from_val(&env, &data)
+            {
                 if ev_bidder == alice && ev_amount == 100_i128 {
                     found = true;
                     break;
@@ -65,7 +67,7 @@ mod tests {
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    Address, BytesN, Env,
+    Address, BytesN, Env, TryFromVal,
 };
 
 // Dummy factory contract (kept for existing tests)
@@ -108,7 +110,7 @@ fn test_claim_username_success() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #1)")]
+#[should_panic(expected = "HostError: Error(Contract, #1001)")]
 fn test_not_winner() {
     let env = Env::default();
     env.mock_all_auths();
@@ -127,7 +129,7 @@ fn test_not_winner() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #2)")]
+#[should_panic(expected = "HostError: Error(Contract, #1002)")]
 fn test_already_claimed() {
     let env = Env::default();
     env.mock_all_auths();
@@ -145,7 +147,7 @@ fn test_already_claimed() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #3)")]
+#[should_panic(expected = "HostError: Error(Contract, #1003)")]
 fn test_not_closed() {
     let env = Env::default();
     env.mock_all_auths();
@@ -163,7 +165,7 @@ fn test_not_closed() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #4)")]
+#[should_panic(expected = "HostError: Error(Contract, #1004)")]
 fn test_no_factory_contract() {
     let env = Env::default();
     env.mock_all_auths();
@@ -221,7 +223,7 @@ fn test_close_auction_zero_bid() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #9)")]
+#[should_panic(expected = "HostError: Error(Contract, #1009)")]
 fn test_close_auction_not_expired() {
     let env = Env::default();
     let contract_id = env.register(AuctionContract, ());
@@ -241,7 +243,7 @@ fn test_close_auction_not_expired() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #8)")]
+#[should_panic(expected = "HostError: Error(Contract, #1008)")]
 fn test_close_auction_not_open() {
     let env = Env::default();
     let contract_id = env.register(AuctionContract, ());
@@ -347,7 +349,7 @@ fn test_refund_bid_success() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #1)")]
+#[should_panic(expected = "Error(Contract, #1001)")]
 fn test_refund_bid_winner_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -370,7 +372,7 @@ fn test_refund_bid_winner_rejected() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #2)")]
+#[should_panic(expected = "Error(Contract, #1002)")]
 fn test_refund_bid_double_refund_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -404,7 +406,7 @@ fn test_auction_no_bids_close() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #7)")]
+#[should_panic(expected = "Error(Contract, #1007)")]
 fn test_create_auction_zero_min_bid_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -413,7 +415,7 @@ fn test_create_auction_zero_min_bid_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #7)")]
+#[should_panic(expected = "Error(Contract, #1007)")]
 fn test_place_bid_too_low_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -424,7 +426,7 @@ fn test_place_bid_too_low_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #8)")]
+#[should_panic(expected = "Error(Contract, #1008)")]
 fn test_place_bid_after_close_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -436,7 +438,7 @@ fn test_place_bid_after_close_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #9)")]
+#[should_panic(expected = "Error(Contract, #1009)")]
 fn test_close_auction_early_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -447,7 +449,7 @@ fn test_close_auction_early_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #8)")]
+#[should_panic(expected = "Error(Contract, #1008)")]
 fn test_close_nonexistent_auction_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -456,7 +458,7 @@ fn test_close_nonexistent_auction_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #1)")]
+#[should_panic(expected = "Error(Contract, #1001)")]
 fn test_claim_not_winner_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -473,7 +475,7 @@ fn test_claim_not_winner_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #9)")]
+#[should_panic(expected = "Error(Contract, #1009)")]
 fn test_create_auction_past_end_time_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -483,7 +485,7 @@ fn test_create_auction_past_end_time_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #8)")]
+#[should_panic(expected = "Error(Contract, #1008)")]
 fn test_create_duplicate_auction_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -493,7 +495,7 @@ fn test_create_duplicate_auction_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #10)")]
+#[should_panic(expected = "Error(Contract, #1005)")]
 fn test_outbid_self_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -508,7 +510,7 @@ fn test_outbid_self_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #2)")]
+#[should_panic(expected = "Error(Contract, #1002)")]
 fn test_claim_twice_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -533,13 +535,23 @@ fn test_create_auction_emits_event() {
     client.create_auction(&1, &seller, &asset, &100, &1000u64);
     
     let events = env.events().all();
-    assert!(events.len() > 0);
+    assert!(!events.is_empty());
     
-    let event = events.last().unwrap();
-    let (_, topics, data) = event;
+    let event = events.last().expect("expected an AuctionCreated event");
+    let (_, topics, _data) = event;
     
-    let event_name = soroban_sdk::Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
-    assert_eq!(event_name, soroban_sdk::Symbol::new(&env, "AuctionCreatedEvent"));
+    let event_name = soroban_sdk::Symbol::try_from_val(
+        &env,
+        &topics.get(0).expect("expected event name topic"),
+    )
+    .expect("event name should deserialize");
+    assert_eq!(
+        event_name,
+        soroban_sdk::Symbol::new(&env, "auction_created_event")
+    );
+}
+
+#[test]
 fn test_get_auction_info() {
     let env = Env::default();
     env.mock_all_auths();
@@ -554,22 +566,30 @@ fn test_get_auction_info() {
     client.create_auction(&1, &seller, &asset, &100, &1000u64);
     
     // Initial state
-    let info1 = client.get_auction_info(&1).unwrap();
+    let info1 = client
+        .get_auction_info(&1)
+        .expect("expected auction info after create");
     assert_eq!(info1, (seller.clone(), asset.clone(), 100, 1000, 0, None, types::AuctionStatus::Open, false));
 
     // After bid
     client.place_bid(&1, &bidder, &150);
-    let info2 = client.get_auction_info(&1).unwrap();
+    let info2 = client
+        .get_auction_info(&1)
+        .expect("expected auction info after bid");
     assert_eq!(info2, (seller.clone(), asset.clone(), 100, 1000, 150, Some(bidder.clone()), types::AuctionStatus::Open, false));
 
     // After close
     env.ledger().set_timestamp(1001);
     client.close_auction_by_id(&1);
-    let info3 = client.get_auction_info(&1).unwrap();
+    let info3 = client
+        .get_auction_info(&1)
+        .expect("expected auction info after close");
     assert_eq!(info3, (seller.clone(), asset.clone(), 100, 1000, 150, Some(bidder.clone()), types::AuctionStatus::Closed, false));
 
     // After claim
     client.claim(&1, &bidder);
-    let info4 = client.get_auction_info(&1).unwrap();
+    let info4 = client
+        .get_auction_info(&1)
+        .expect("expected auction info after claim");
     assert_eq!(info4, (seller.clone(), asset.clone(), 100, 1000, 150, Some(bidder.clone()), types::AuctionStatus::Closed, true));
 }

--- a/gateway-contract/contracts/auction_contract/src/types.rs
+++ b/gateway-contract/contracts/auction_contract/src/types.rs
@@ -31,8 +31,6 @@ pub enum AuctionKey {
     BidRefunded(u32, Address),
     Status(u32),
     Claimed(u32),
-    OutbidAmount(u32, Address),
-    BidRefunded(u32, Address),
     UsernameHash(u32),
 }
 


### PR DESCRIPTION
📝 Description

Status checks like if status != AuctionStatus::Open are repeated across close_auction and claim_username. Extract fn require_status(env, status, expected, err) and use it in both functions.

closing #269 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tracking for key auction lifecycle events (creation, bids placed, bids refunded, and closure)

* **Bug Fixes**
  * Improved validation when creating auctions and placing bids
  * Enhanced auction status verification during closure and claiming operations

* **Tests**
  * Strengthened test suite with improved event verification and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->