### PR TITLE
feat: implement auction storage helpers 

### DIFF
--- a/gateway-contract/Cargo.lock
+++ b/gateway-contract/Cargo.lock
@@ -151,6 +151,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "auction_contract"
+version = "0.1.0"
+dependencies = [
+ "shared",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,14 +648,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "gateway-auction"
-version = "0.1.0"
-dependencies = [
- "shared",
- "soroban-sdk",
-]
 
 [[package]]
 name = "generic-array"

--- a/gateway-contract/contracts/auction_contract/Cargo.toml
+++ b/gateway-contract/contracts/auction_contract/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gateway-auction"
+name = "auction_contract"
 version = "0.1.0"
 edition = "2021"
 description = "Simple auction contract for testing BidRefundedEvent emission"

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -155,3 +155,23 @@ impl AuctionContract {
         ))
     }
 }
+
+/// CRUD helpers for hash-indexed auction storage.
+#[contractimpl]
+impl AuctionContract {
+    pub fn get_auction(env: Env, hash: BytesN<32>) -> Option<types::AuctionState> {
+        storage::get_auction(&env, &hash)
+    }
+
+    pub fn has_auction(env: Env, hash: BytesN<32>) -> bool {
+        storage::has_auction(&env, &hash)
+    }
+
+    pub fn get_bid(env: Env, hash: BytesN<32>, bidder: Address) -> Option<types::Bid> {
+        storage::get_bid(&env, &hash, &bidder)
+    }
+
+    pub fn get_all_bidders(env: Env, hash: BytesN<32>) -> soroban_sdk::Vec<Address> {
+        storage::get_all_bidders(&env, &hash)
+    }
+}

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -1,5 +1,5 @@
-use crate::types::{AuctionStatus, DataKey};
-use soroban_sdk::{Address, BytesN, Env};
+use crate::types::{AuctionState, AuctionStatus, Bid, InstanceKey};
+use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 
 /// TTL constants for persistent storage entries.
 /// PERSISTENT_BUMP_AMOUNT: 30 days × 24h × 3600s / 5s per ledger = 518_400 ledgers
@@ -7,54 +7,61 @@ pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400; // 30 * 24 * 3600 / 5
 /// PERSISTENT_LIFETIME_THRESHOLD: 7 days × 24h × 3600s / 5s per ledger = 120_960 ledgers
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960; // 7 * 24 * 3600 / 5
 
+#[contracttype]
+pub enum DataKey {
+    Auction(BytesN<32>),
+    Bid(BytesN<32>, Address),
+    AllBidders(BytesN<32>),
+}
+
 pub fn get_status(env: &Env) -> AuctionStatus {
     env.storage()
         .instance()
-        .get(&DataKey::Status)
+        .get(&InstanceKey::Status)
         .unwrap_or(AuctionStatus::Open)
 }
 
 pub fn set_status(env: &Env, status: AuctionStatus) {
-    env.storage().instance().set(&DataKey::Status, &status);
+    env.storage().instance().set(&InstanceKey::Status, &status);
 }
 
 pub fn get_highest_bidder(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&DataKey::HighestBidder)
+    env.storage().instance().get(&InstanceKey::HighestBidder)
 }
 
 pub fn set_highest_bidder(env: &Env, bidder: &Address) {
     env.storage()
         .instance()
-        .set(&DataKey::HighestBidder, bidder);
+        .set(&InstanceKey::HighestBidder, bidder);
 }
 
 pub fn get_factory_contract(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&DataKey::FactoryContract)
+    env.storage().instance().get(&InstanceKey::FactoryContract)
 }
 
 pub fn set_factory_contract(env: &Env, factory: &Address) {
     env.storage()
         .instance()
-        .set(&DataKey::FactoryContract, factory);
+        .set(&InstanceKey::FactoryContract, factory);
 }
 
 pub fn get_end_time(env: &Env) -> u64 {
-    env.storage().instance().get(&DataKey::EndTime).unwrap_or(0)
+    env.storage().instance().get(&InstanceKey::EndTime).unwrap_or(0)
 }
 
 pub fn set_end_time(env: &Env, end_time: u64) {
-    env.storage().instance().set(&DataKey::EndTime, &end_time);
+    env.storage().instance().set(&InstanceKey::EndTime, &end_time);
 }
 
 pub fn get_highest_bid(env: &Env) -> u128 {
     env.storage()
         .instance()
-        .get(&DataKey::HighestBid)
+        .get(&InstanceKey::HighestBid)
         .unwrap_or(0)
 }
 
 pub fn set_highest_bid(env: &Env, bid: u128) {
-    env.storage().instance().set(&DataKey::HighestBid, &bid);
+    env.storage().instance().set(&InstanceKey::HighestBid, &bid);
 }
 
 // --- id-scoped auction storage ---
@@ -248,4 +255,59 @@ pub fn auction_set_bid_refunded(env: &Env, id: u32, bidder: &Address) {
         PERSISTENT_LIFETIME_THRESHOLD,
         PERSISTENT_BUMP_AMOUNT,
     );
+}
+
+// --- persistent storage helpers for AuctionState and Bid ---
+
+pub fn get_auction(env: &Env, hash: &BytesN<32>) -> Option<AuctionState> {
+    env.storage().persistent().get(&DataKey::Auction(hash.clone()))
+}
+
+pub fn set_auction(env: &Env, hash: &BytesN<32>, state: &AuctionState) {
+    let key = DataKey::Auction(hash.clone());
+    env.storage().persistent().set(&key, state);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+pub fn has_auction(env: &Env, hash: &BytesN<32>) -> bool {
+    env.storage().persistent().has(&DataKey::Auction(hash.clone()))
+}
+
+pub fn get_bid(env: &Env, hash: &BytesN<32>, bidder: &Address) -> Option<Bid> {
+    env.storage().persistent().get(&DataKey::Bid(hash.clone(), bidder.clone()))
+}
+
+pub fn set_bid(env: &Env, hash: &BytesN<32>, bidder: &Address, bid: &Bid) {
+    let key = DataKey::Bid(hash.clone(), bidder.clone());
+    env.storage().persistent().set(&key, bid);
+    env.storage().persistent().extend_ttl(
+        &key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+pub fn get_all_bidders(env: &Env, hash: &BytesN<32>) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AllBidders(hash.clone()))
+        .unwrap_or(Vec::new(env))
+}
+
+pub fn add_bidder(env: &Env, hash: &BytesN<32>, bidder: Address) {
+    let mut bidders = get_all_bidders(env, hash);
+    if !bidders.contains(&bidder) {
+        bidders.push_back(bidder);
+        let key = DataKey::AllBidders(hash.clone());
+        env.storage().persistent().set(&key, &bidders);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
 }

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -46,11 +46,16 @@ pub fn set_factory_contract(env: &Env, factory: &Address) {
 }
 
 pub fn get_end_time(env: &Env) -> u64 {
-    env.storage().instance().get(&InstanceKey::EndTime).unwrap_or(0)
+    env.storage()
+        .instance()
+        .get(&InstanceKey::EndTime)
+        .unwrap_or(0)
 }
 
 pub fn set_end_time(env: &Env, end_time: u64) {
-    env.storage().instance().set(&InstanceKey::EndTime, &end_time);
+    env.storage()
+        .instance()
+        .set(&InstanceKey::EndTime, &end_time);
 }
 
 pub fn get_highest_bid(env: &Env) -> u128 {
@@ -260,7 +265,9 @@ pub fn auction_set_bid_refunded(env: &Env, id: u32, bidder: &Address) {
 // --- persistent storage helpers for AuctionState and Bid ---
 
 pub fn get_auction(env: &Env, hash: &BytesN<32>) -> Option<AuctionState> {
-    env.storage().persistent().get(&DataKey::Auction(hash.clone()))
+    env.storage()
+        .persistent()
+        .get(&DataKey::Auction(hash.clone()))
 }
 
 pub fn set_auction(env: &Env, hash: &BytesN<32>, state: &AuctionState) {
@@ -274,11 +281,15 @@ pub fn set_auction(env: &Env, hash: &BytesN<32>, state: &AuctionState) {
 }
 
 pub fn has_auction(env: &Env, hash: &BytesN<32>) -> bool {
-    env.storage().persistent().has(&DataKey::Auction(hash.clone()))
+    env.storage()
+        .persistent()
+        .has(&DataKey::Auction(hash.clone()))
 }
 
 pub fn get_bid(env: &Env, hash: &BytesN<32>, bidder: &Address) -> Option<Bid> {
-    env.storage().persistent().get(&DataKey::Bid(hash.clone(), bidder.clone()))
+    env.storage()
+        .persistent()
+        .get(&DataKey::Bid(hash.clone(), bidder.clone()))
 }
 
 pub fn set_bid(env: &Env, hash: &BytesN<32>, bidder: &Address, bid: &Bid) {

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -102,8 +102,10 @@ mod tests {
 
         let mut found = false;
         for (_contract, topics, data) in events.iter().rev() {
-            let event_name: Result<soroban_sdk::Symbol, _> =
-                soroban_sdk::Symbol::try_from_val(&env, &topics.get(0).unwrap());
+            let event_name: Result<soroban_sdk::Symbol, _> = soroban_sdk::Symbol::try_from_val(
+                &env,
+                &topics.get(0).expect("event topic missing"),
+            );
             if let Ok(name) = event_name {
                 if name == soroban_sdk::Symbol::new(&env, "BID_PLCD") {
                     if let Ok((ev_bidder, ev_amount)) = <(Address, i128)>::try_from_val(&env, &data)

--- a/gateway-contract/contracts/auction_contract/src/types.rs
+++ b/gateway-contract/contracts/auction_contract/src/types.rs
@@ -10,7 +10,7 @@ pub enum AuctionStatus {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum DataKey {
+pub enum InstanceKey {
     Status,
     HighestBidder,
     FactoryContract,

--- a/gateway-contract/contracts/core_contract/src/address_manager.rs
+++ b/gateway-contract/contracts/core_contract/src/address_manager.rs
@@ -250,7 +250,9 @@ impl AddressManager {
                         .persistent()
                         .remove(&storage::DataKey::StellarAddress(username_hash.clone()));
                 } else {
-                    let last = updated.get(updated.len() - 1).unwrap();
+                    let last = updated
+                        .get(updated.len() - 1)
+                        .expect("updated stellar address list should be non-empty");
                     env.storage().persistent().set(
                         &storage::DataKey::StellarAddress(username_hash.clone()),
                         &last,

--- a/gateway-contract/contracts/core_contract/src/alien_gateway.rs
+++ b/gateway-contract/contracts/core_contract/src/alien_gateway.rs
@@ -1,0 +1,3 @@
+//! Alien Gateway helper module namespace.
+
+pub mod storage;

--- a/gateway-contract/contracts/core_contract/src/alien_gateway/storage.rs
+++ b/gateway-contract/contracts/core_contract/src/alien_gateway/storage.rs
@@ -10,9 +10,13 @@ pub fn smt_root_key(env: &Env) -> Symbol {
     Symbol::new(env, "SmtRoot")
 }
 
-pub fn owner_key(env: &Env) -> Symbol { Symbol::new(env, "Owner") }
+pub fn owner_key(env: &Env) -> Symbol {
+    Symbol::new(env, "Owner")
+}
 
-pub fn username_key(env: &Env) -> Symbol { Symbol::new(env, "Username") }
+pub fn username_key(env: &Env) -> Symbol {
+    Symbol::new(env, "Username")
+}
 
 pub fn created_at_key(env: &Env, _username_hash: &BytesN<32>) -> Symbol {
     Symbol::new(env, "CreatedAt")

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -89,13 +89,13 @@
 
 pub mod address_manager;
 pub mod admin;
+pub mod alien_gateway;
 pub mod errors;
 pub mod events;
 pub mod registration;
 pub mod resolver;
 pub mod smt_root;
 pub mod storage;
-pub mod alien_gateway;
 pub mod transfer;
 pub mod types;
 pub mod zk_verifier;
@@ -107,7 +107,7 @@ use address_manager::AddressManager;
 use admin::Admin;
 use registration::Registration;
 use resolver::Resolver;
-use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, Symbol};
 use transfer::Transfer;
 use types::{ChainType, PrivacyMode, PublicSignals};
 
@@ -149,6 +149,9 @@ impl Contract {
 
     /// Gets the owner of a commitment. See [registration::Registration::get_owner].
     pub fn get_owner(e: Env, h: BytesN<32>) -> Option<Address> { Registration::get_owner(e, h) }
+
+    /// Gets the stored username symbol when present.
+    pub fn get_username(e: Env) -> Option<Symbol> { e.storage().instance().get(&alien_gateway::storage::username_key(&e)) }
 
     /// Gets the registration ledger timestamp for a commitment. See [registration::Registration::get_created_at].
     pub fn get_created_at(e: Env, h: BytesN<32>) -> Option<u64> { Registration::get_created_at(e, h) }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -27,10 +27,11 @@ fn commitment(env: &Env, seed: u8) -> BytesN<32> {
     BytesN::from_array(env, &[seed; 32])
 }
 
-fn assert_event_symbol(env: &Env, event: &(Address, std::vec::Vec<Val>, Val), expected: Symbol) {
+fn assert_event_symbol(env: &Env, event: &(Address, Vec<Val>, Val), expected: Symbol) {
     use soroban_sdk::TryFromVal;
 
-    let event_name = Symbol::try_from_val(env, &event.1.get(0).unwrap()).unwrap();
+    let event_topic = event.1.get(0).expect("event topic missing");
+    let event_name = Symbol::try_from_val(env, &event_topic).expect("event name should decode");
     assert_eq!(event_name, expected);
 }
 
@@ -94,9 +95,10 @@ fn test_get_username_returns_stored_username() {
     let username = Symbol::new(&env, "alien_user");
 
     env.as_contract(&contract_id, || {
-        env.storage()
-            .instance()
-            .set(&crate::alien_gateway::storage::username_key(&env), &username);
+        env.storage().instance().set(
+            &crate::alien_gateway::storage::username_key(&env),
+            &username,
+        );
     });
 
     assert_eq!(client.get_username(), Some(username));
@@ -610,7 +612,7 @@ fn test_remove_stellar_address_success() {
     // addr_b must be absent from the history list
     let addresses = client.get_stellar_addresses(&hash);
     assert_eq!(addresses.len(), 1);
-    assert_eq!(addresses.get(0).unwrap(), addr_a);
+    assert_eq!(addresses.get(0).expect("first address missing"), addr_a);
 
     // primary falls back to addr_a
     assert_eq!(client.resolve_stellar(&hash), addr_a);
@@ -1040,7 +1042,11 @@ fn test_transfer_succeeds() {
 
     env.as_contract(&contract_id, || {
         let key = RegKey::Commitment(hash.clone());
-        let current_owner: Address = env.storage().persistent().get(&key).unwrap();
+        let current_owner: Address = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("owner should be stored");
 
         if owner != current_owner {
             panic_with_error!(&env, CoreError::Unauthorized);
@@ -1156,8 +1162,8 @@ fn test_full_identity_lifecycle() {
     client.register(&owner, &hash);
     let events = env.events().all();
     assert_eq!(events.len(), events_len + 1);
-    let register_event = events.last().unwrap();
-    assert_event_symbol(&env, register_event, REGISTER_EVENT);
+    let register_event = events.last().expect("register event missing");
+    assert_event_symbol(&env, &register_event, REGISTER_EVENT);
     let (commitment, registered_owner): (BytesN<32>, Address) = register_event.2.into_val(&env);
     assert_eq!(commitment, hash);
     assert_eq!(registered_owner, owner);
@@ -1172,8 +1178,8 @@ fn test_full_identity_lifecycle() {
     client.update_smt_root(&root1);
     let events = env.events().all();
     assert_eq!(events.len(), events_len + 1);
-    let root_event = events.last().unwrap();
-    assert_event_symbol(&env, root_event, ROOT_UPDATED);
+    let root_event = events.last().expect("root update event missing");
+    assert_event_symbol(&env, &root_event, ROOT_UPDATED);
     let (old_root, new_root): (Option<BytesN<32>>, BytesN<32>) = root_event.2.into_val(&env);
     assert_eq!(old_root, None);
     assert_eq!(new_root, root1);
@@ -1200,16 +1206,18 @@ fn test_full_identity_lifecycle() {
 
     let events = env.events().all();
     assert_eq!(events.len(), events_len + 2);
-    let transfer_event = events.last().unwrap();
-    assert_event_symbol(&env, transfer_event, TRANSFER_EVENT);
+    let transfer_event = events.last().expect("transfer event missing");
+    assert_event_symbol(&env, &transfer_event, TRANSFER_EVENT);
     let (commitment, from_owner, to_owner): (BytesN<32>, Address, Address) =
         transfer_event.2.into_val(&env);
     assert_eq!(commitment, hash);
     assert_eq!(from_owner, owner);
     assert_eq!(to_owner, new_owner);
 
-    let root_event = &events[events.len() - 2];
-    assert_event_symbol(&env, root_event, ROOT_UPDATED);
+    let root_event = events
+        .get(events.len() - 2)
+        .expect("previous root event missing");
+    assert_event_symbol(&env, &root_event, ROOT_UPDATED);
     let (old_root, new_root): (Option<BytesN<32>>, BytesN<32>) = root_event.2.into_val(&env);
     assert_eq!(old_root, Some(root1));
     assert_eq!(new_root, root2);
@@ -1223,8 +1231,8 @@ fn test_full_identity_lifecycle() {
     client.update_smt_root(&root3);
     let events = env.events().all();
     assert_eq!(events.len(), events_len + 1);
-    let root_event = events.last().unwrap();
-    assert_event_symbol(&env, root_event, ROOT_UPDATED);
+    let root_event = events.last().expect("final root update event missing");
+    assert_event_symbol(&env, &root_event, ROOT_UPDATED);
     let (old_root, new_root): (Option<BytesN<32>>, BytesN<32>) = root_event.2.into_val(&env);
     assert_eq!(old_root, Some(root2));
     assert_eq!(new_root, root3);
@@ -1350,7 +1358,8 @@ fn test_update_root_emits_event() {
     assert_eq!(last_event.0, contract_id);
 
     // Decode the Val back into a Symbol to properly compare it
-    let event_name = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    let event_topic = last_event.1.get(0).expect("event topic missing");
+    let event_name = Symbol::try_from_val(&env, &event_topic).expect("event name should decode");
     assert_eq!(event_name, Symbol::new(&env, "ROOT_UPD"));
 
     let (old, new): (Option<BytesN<32>>, BytesN<32>) = last_event.2.into_val(&env);

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -135,7 +135,7 @@ fn test_legacy_vault_key_fallback_and_migration() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, 1200);
         assert!(state.is_active);
 
@@ -143,7 +143,7 @@ fn test_legacy_vault_key_fallback_and_migration() {
             .storage()
             .persistent()
             .get(&DataKey::Vault(from.clone()))
-            .unwrap();
+            .expect("legacy vault should exist");
         assert_eq!(legacy.owner, owner);
         assert_eq!(legacy.token, token);
     });
@@ -181,7 +181,7 @@ fn test_get_scheduled_payment_returns_all_fields_after_schedule() {
         "expected Some(ScheduledPayment) for a known payment_id"
     );
 
-    let payment = result.unwrap();
+    let payment = result.expect("scheduled payment should exist");
     assert_eq!(payment.from, from);
     assert_eq!(payment.to, to);
     assert_eq!(payment.amount, amount);
@@ -229,7 +229,7 @@ fn test_schedule_payment_success() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, initial_balance - amount);
 
         // Verify VaultConfig is unmodified after payment scheduling
@@ -237,7 +237,7 @@ fn test_schedule_payment_success() {
             .storage()
             .persistent()
             .get(&DataKey::VaultConfig(from.clone()))
-            .unwrap();
+            .expect("vault config should exist");
         assert_eq!(config.token, token);
 
         // Verify ScheduledPayment stored correctly
@@ -245,7 +245,7 @@ fn test_schedule_payment_success() {
             .storage()
             .persistent()
             .get(&DataKey::ScheduledPayment(payment_id))
-            .unwrap();
+            .expect("scheduled payment should exist");
         assert_eq!(payment.from, from);
         assert_eq!(payment.to, to);
         assert_eq!(payment.amount, amount);
@@ -416,7 +416,7 @@ fn test_execute_scheduled_success() {
             .storage()
             .persistent()
             .get(&DataKey::ScheduledPayment(payment_id))
-            .unwrap();
+            .expect("scheduled payment should exist");
         assert!(payment.executed);
     });
 
@@ -502,7 +502,7 @@ fn test_create_vault_success() {
             .storage()
             .persistent()
             .get(&DataKey::VaultConfig(commitment.clone()))
-            .unwrap();
+            .expect("vault config should exist");
         assert_eq!(config.owner, owner);
         assert_eq!(config.token, token);
 
@@ -511,7 +511,7 @@ fn test_create_vault_success() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(commitment.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, 0);
         assert!(state.is_active);
     });
@@ -634,7 +634,7 @@ fn test_deposit_success() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, initial_balance + deposit_amount);
     });
 
@@ -720,7 +720,7 @@ fn test_withdraw_success() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, initial_balance - withdraw_amount);
         assert!(state.is_active);
     });
@@ -898,7 +898,7 @@ fn test_withdraw_success_with_token_transfer() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, initial_balance);
     });
 
@@ -909,7 +909,7 @@ fn test_withdraw_success_with_token_transfer() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, initial_balance - withdraw_amount);
     });
 
@@ -1009,7 +1009,7 @@ fn test_withdraw_overdraft() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert_eq!(state.balance, balance);
     });
 }
@@ -1150,7 +1150,7 @@ fn test_cancel_vault_refunds_balance() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert!(!state.is_active);
         assert_eq!(state.balance, 0);
     });
@@ -1172,7 +1172,7 @@ fn test_cancel_vault_empty_balance() {
             .storage()
             .persistent()
             .get(&DataKey::VaultState(from.clone()))
-            .unwrap();
+            .expect("vault state should exist");
         assert!(!state.is_active);
         assert_eq!(state.balance, 0);
     });
@@ -1347,7 +1347,7 @@ fn test_get_auto_pay_returns_rule_after_setup() {
         "expected Some(AutoPay) after setup_auto_pay"
     );
 
-    let rule = result.unwrap();
+    let rule = result.expect("auto-pay rule should exist");
     assert_eq!(rule.from, from);
     assert_eq!(rule.to, to);
     assert_eq!(rule.amount, amount);
@@ -1610,7 +1610,7 @@ fn test_cancel_auto_pay_does_not_affect_sibling_rules() {
         "rule_b must survive cancellation of rule_a"
     );
     assert_eq!(
-        surviving.unwrap().amount,
+        surviving.expect("surviving payment should exist").amount,
         200,
         "rule_b amount must be unchanged after rule_a cancel"
     );

--- a/gateway-contract/shared/src/errors.rs
+++ b/gateway-contract/shared/src/errors.rs
@@ -98,6 +98,8 @@ pub enum CoreError {
     AlreadyInitialized = 4009,
     /// Commitment is already registered via register().
     AlreadyRegistered = 4010,
+    /// The new SMT root matches the existing on-chain root.
+    RootUnchanged = 4011,
 }
 
 #[contracterror]

--- a/gateway-contract/tests/e2e/test_full_flow.rs
+++ b/gateway-contract/tests/e2e/test_full_flow.rs
@@ -143,7 +143,10 @@ fn e2e_escrow_deposit_schedule_payment() {
         escrow_contract::storage::read_vault_state(&env, &hash)
     });
     assert_eq!(
-        state.as_ref().unwrap().balance,
+        state
+            .as_ref()
+            .expect("vault state should exist after payment")
+            .balance,
         1000,
         "Vault balance should be 1000 after deposit"
     );
@@ -177,14 +180,17 @@ fn e2e_escrow_deposit_schedule_payment() {
             500,
             release_at,
         )
-        .unwrap()
+        .expect("scheduled payment should be stored")
     });
     // Assert vault state after scheduling payment (should be 500)
     let state: Option<VaultState> = env.as_contract(&escrow_id, || {
         escrow_contract::storage::read_vault_state(&env, &hash)
     });
     assert_eq!(
-        state.as_ref().unwrap().balance,
+        state
+            .as_ref()
+            .expect("vault state should exist after execution")
+            .balance,
         500,
         "Vault balance should be 500 after scheduling payment"
     );
@@ -207,12 +213,12 @@ fn e2e_escrow_deposit_schedule_payment() {
             "[TEST DEBUG] execute_scheduled: contract address = {:?}",
             env.current_contract_address()
         );
-        EscrowContract::execute_scheduled(env.clone(), payment_id);
+        let _ = EscrowContract::execute_scheduled(env.clone(), payment_id);
     });
 
     // Assert vault state updated (balance should be 500)
     let state: VaultState = env.as_contract(&escrow_id, || {
-        escrow_contract::storage::read_vault_state(&env, &hash).unwrap()
+        escrow_contract::storage::read_vault_state(&env, &hash).expect("vault state should exist")
     });
     assert_eq!(state.balance, 500);
 }

--- a/zk/circuits/username_hash_main.circom
+++ b/zk/circuits/username_hash_main.circom
@@ -1,6 +1,5 @@
 pragma circom 2.0.0;
 
-include "username_hash_impl.circom";
 include "username_hash.circom";
 
 component main = UsernameHash();


### PR DESCRIPTION
Closes: #95 

Implement persistent storage CRUD helpers for the auction contract in [auction_contract/src/storage.rs](cci:7://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/storage.rs:0:0-0:0). This provides the foundation for managing multiple concurrent auctions identified by a 32-byte hash.

## Changes:
- **[types.rs](cci:7://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/types.rs:0:0-0:0)**: Renamed existing instance-scoped `DataKey` to `InstanceKey` to avoid naming conflicts with the new persistent storage keys.
- **[storage.rs](cci:7://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/storage.rs:0:0-0:0)**:
    - Defined a new `DataKey` enum with variants: [Auction(BytesN<32>)](cci:2://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/types.rs:47:0-52:1), [Bid(BytesN<32>, Address)](cci:2://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/types.rs:56:0-60:1), and `AllBidders(BytesN<32>)`.
    - Implemented CRUD helpers: [get_auction](cci:1://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/lib.rs:161:4-163:5), [set_auction](cci:1://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/storage.rs:265:0-273:1), [has_auction](cci:1://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/lib.rs:165:4-167:5), [get_bid](cci:1://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/storage.rs:279:0-281:1), [set_bid](cci:1://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/storage.rs:283:0-291:1), [get_all_bidders](cci:1://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/lib.rs:173:4-175:5), and [add_bidder](cci:1://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/storage.rs:300:0-312:1).
    - Integrated persistent storage TTL management (bump amount and threshold).
    - Updated existing singleton helpers to use `InstanceKey`.
- **[lib.rs](cci:7://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/lib.rs:0:0-0:0)**: Exposed new storage helpers via public contract methods to ensure they are properly wired and linked.

## Verification:
- [x] All helpers implemented in [storage.rs](cci:7://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/storage.rs:0:0-0:0)
- [x] `DataKey` enum defined and wired to persistent storage
- [x] Imported and used in [lib.rs](cci:7://file:///c:/Users/USER/Desktop/drips/Alien-Gateway/gateway-contract/contracts/auction_contract/src/lib.rs:0:0-0:0)
- [x] `cargo build`/`cargo check` passes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only auction query methods to fetch auction details, check existence, retrieve a bidder's bid, and list all bidders.
  * Added a username lookup method to the core contract.

* **Tests**
  * Strengthened test assertions and improved failure messages across multiple contracts for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->