### PR TITLE
 feat: alien-gateway emit StellarAddressAdded event on add_stellar_ad…

### DIFF
--- a/gateway-contract/contracts/core_contract/src/address_manager.rs
+++ b/gateway-contract/contracts/core_contract/src/address_manager.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, BytesN, Env, Vec};
 
 use crate::errors::{ChainAddressError, CoreError};
-use crate::events::{shielded_add_event, stellar_rem_event, CHAIN_ADD, CHAIN_REM};
+use crate::events::{shielded_add_event, stellar_rem_event, CHAIN_ADD, CHAIN_REM, ADDR_ADD};
 use crate::registration::{DataKey as CommitmentKey, Registration};
 use crate::storage::{self, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
 use crate::types::ChainType;
@@ -152,7 +152,7 @@ impl AddressManager {
     /// - `NotFound`: If the commitment is not registered.
     ///
     /// ### Events
-    /// - No explicit event emitted (stored in persistent storage).
+    /// - Emits `ADDR_ADD` event with stellar_address as data.
     pub fn add_stellar_address(
         env: Env,
         caller: Address,
@@ -183,6 +183,10 @@ impl AddressManager {
             &storage::DataKey::StellarAddress(username_hash),
             &stellar_address,
         );
+
+        #[allow(deprecated)]
+        env.events()
+            .publish((ADDR_ADD,), stellar_address.clone());
     }
 
     /// Removes a specific Stellar address linked to a registered commitment.

--- a/gateway-contract/contracts/core_contract/src/events.rs
+++ b/gateway-contract/contracts/core_contract/src/events.rs
@@ -8,6 +8,7 @@ pub const REGISTER_EVENT: Symbol = symbol_short!("REGISTER");
 pub const ROOT_UPDATED: Symbol = symbol_short!("ROOT_UPD");
 pub const MASTER_SET: Symbol = symbol_short!("MSTR_SET");
 pub const ADDR_ADDED: Symbol = symbol_short!("ADDR_ADD");
+pub const ADDR_ADD: Symbol = symbol_short!("ADDR_ADD");
 pub const CHAIN_ADD: Symbol = symbol_short!("CHAIN_ADD");
 pub const CHAIN_REM: Symbol = symbol_short!("CHAIN_REM");
 pub const VAULT_CREATE: Symbol = symbol_short!("VAULT_CRT");


### PR DESCRIPTION
est_add_stellar_address_success.1.json shows zero events after a successful add. Define ADDR_ADD symbol and emit (ADDR_ADD, stellar_address) with label as data. Update test snapshot.

Closes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stellar address additions now emit an on-chain event, enabling tracking and monitoring of address additions on the blockchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->