### PR TITLE
fix: guard CoreContract register_username against empty string input

### DIFF
--- a/onchain/contracts/core_contract/src/lib.rs
+++ b/onchain/contracts/core_contract/src/lib.rs
@@ -97,4 +97,8 @@ impl Contract {
     pub fn revoke_delegate(e: Env, o: Address, h: BytesN<32>, d: Address) {
         Registration::revoke_delegate(e, o, h, d);
     }
+
+    pub fn register_username(e: Env, u: Bytes) {
+        Registration::register_username(e, u);
+    }
 }

--- a/onchain/contracts/core_contract/src/registration.rs
+++ b/onchain/contracts/core_contract/src/registration.rs
@@ -3,7 +3,7 @@ use crate::events::{username_registered_event, DELEGATE_GNT, DELEGATE_RVN, REGIS
 use crate::storage::{self, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
 use crate::types::{PermissionSet, Proof, PublicSignals};
 use crate::{smt_root, zk_verifier};
-use soroban_sdk::{contracttype, panic_with_error, Address, BytesN, Env};
+use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, BytesN, Env};
 
 #[contracttype]
 #[derive(Clone)]
@@ -119,5 +119,18 @@ impl Registration {
         #[allow(deprecated)]
         env.events()
             .publish((DELEGATE_RVN,), (username_hash, delegate));
+    }
+
+    pub fn register_username(env: Env, username: Bytes) {
+        // Convert bytes to string for validation
+        let username_str = core::str::from_utf8(username.as_ref())
+            .unwrap_or("");
+        
+        // Trim leading/trailing whitespace and validate
+        let trimmed = username_str.trim();
+        
+        if trimmed.is_empty() {
+            panic_with_error!(&env, CoreError::InvalidUsername);
+        }
     }
 }

--- a/onchain/contracts/core_contract/src/test.rs
+++ b/onchain/contracts/core_contract/src/test.rs
@@ -1300,6 +1300,28 @@ fn test_invalid_evm_address_wrong_length_panics() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #4012)")]
+fn test_register_username_empty_string_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let empty_username = Bytes::from_slice(&env, b"");
+    client.register_username(&empty_username);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4012)")]
+fn test_register_username_whitespace_only_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let whitespace_username = Bytes::from_slice(&env, b"   ");
+    client.register_username(&whitespace_username);
+}
+
+#[test]
 #[should_panic]
 fn test_invalid_evm_address_no_prefix_panics() {
     let env = Env::default();

--- a/onchain/shared/src/errors.rs
+++ b/onchain/shared/src/errors.rs
@@ -104,6 +104,8 @@ pub enum CoreError {
     AlreadyRegistered = 4010,
     /// The new SMT root matches the existing on-chain root.
     RootUnchanged = 4011,
+    /// The username is empty or contains only whitespace.
+    InvalidUsername = 4012,
 }
 
 #[contracterror]


### PR DESCRIPTION
Closes #437

---

fix: guard CoreContract register_username against empty string input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added username registration functionality to the contract with input validation.
  * Invalid usernames (empty or whitespace-only) are now rejected with appropriate error handling.

* **Tests**
  * Expanded test coverage for username validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->