### PR TITLE
Implement vault pause

### DIFF
--- a/contracts/collateral-vault/src/errors.rs
+++ b/contracts/collateral-vault/src/errors.rs
@@ -7,4 +7,5 @@ pub enum VaultError {
     InvalidInputs = 1,
     VaultPaused = 2,
     UnsupportedAsset = 3,
+    AlreadyPaused = 4,
 }

--- a/contracts/collateral-vault/src/events.rs
+++ b/contracts/collateral-vault/src/events.rs
@@ -7,3 +7,9 @@ pub struct Deposited {
     pub asset: Address,
     pub amount: i128,
 }
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Paused {
+    pub by: Address,
+}

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -18,9 +18,26 @@ impl VaultContract {
     }
 
     pub fn set_paused(env: Env, paused: bool) {
+        if paused {
+            Self::pause(env);
+            return;
+        }
+
         let admin = storage::get_admin(&env).expect("not initialized");
         admin.require_auth();
         storage::set_paused(&env, paused);
+    }
+
+    pub fn pause(env: Env) {
+        let admin = storage::get_admin(&env).expect("not initialized");
+        admin.require_auth();
+
+        if storage::is_paused(&env) {
+            soroban_sdk::panic_with_error!(&env, VaultError::AlreadyPaused);
+        }
+
+        storage::pause(&env);
+        events::Paused { by: admin }.publish(&env);
     }
 
     pub fn add_supported_asset(env: Env, asset: Address) {
@@ -77,7 +94,11 @@ impl VaultContract {
         .publish(&env);
     }
 
-    pub fn withdraw(_env: Env, _reciver: Address, _asset: Address, _amount: i128) {}
+    pub fn withdraw(env: Env, _receiver: Address, _asset: Address, _amount: i128) {
+        if storage::is_paused(&env) {
+            soroban_sdk::panic_with_error!(&env, VaultError::VaultPaused);
+        }
+    }
 
     pub fn seize_collateral(_env: Env, _user: Address, _asset: Address, _amount: i128) {}
 

--- a/contracts/collateral-vault/src/storage.rs
+++ b/contracts/collateral-vault/src/storage.rs
@@ -20,6 +20,10 @@ pub fn set_paused(env: &Env, paused: bool) {
     env.storage().persistent().set(&DataKey::Paused, &paused);
 }
 
+pub fn pause(env: &Env) {
+    set_paused(env, true);
+}
+
 pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
     env.storage()
         .persistent()

--- a/contracts/collateral-vault/src/test.rs
+++ b/contracts/collateral-vault/src/test.rs
@@ -1,25 +1,43 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{token, Address, Env};
+use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::{symbol_short, token, Address, Env, IntoVal, Map, Symbol, TryIntoVal, Val};
+
+fn setup_initialized_vault<'a>(env: &'a Env) -> (Address, VaultContractClient<'a>, Address) {
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let oracle = Address::generate(env);
+
+    client.initialize(&admin, &oracle);
+
+    (contract_id, client, admin)
+}
+
+fn setup_vault_with_stored_admin<'a>(env: &'a Env) -> (Address, VaultContractClient<'a>, Address) {
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_admin(env, &admin);
+        storage::set_paused(env, false);
+    });
+
+    (contract_id, client, admin)
+}
 
 #[test]
 fn test_vault_deposit_flow() {
     let env = Env::default();
     env.mock_all_auths();
 
-    // Deploy contract
-    let contract_id = env.register(VaultContract, ());
-    let client = VaultContractClient::new(&env, &contract_id);
+    // Deploy and initialize contract
+    let (contract_id, client, _admin) = setup_initialized_vault(&env);
 
-    // Create address for admin, user, and oracle
-    let admin = Address::generate(&env);
+    // Create address for user
     let user = Address::generate(&env);
-    let oracle = Address::generate(&env);
-
-    // Initialize vault
-    client.initialize(&admin, &oracle);
 
     // Deploy standard token asset
     let token_admin = Address::generate(&env);
@@ -62,10 +80,19 @@ fn test_vault_deposit_flow() {
     assert_eq!(index.len(), 1);
     assert_eq!(index.get(0).unwrap(), user);
 
-    // Pause vault and attempt deposit
-    client.set_paused(&true);
-    let res = client.try_deposit(&user, &token_contract_id, &100);
-    assert!(res.is_err(), "should panic when vault is paused");
+    // Pause vault and attempt user-facing operations
+    client.pause();
+    let err = client
+        .try_deposit(&user, &token_contract_id, &100)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(VaultError::try_from(err).unwrap(), VaultError::VaultPaused);
+
+    let err = client
+        .try_withdraw(&user, &token_contract_id, &100)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(VaultError::try_from(err).unwrap(), VaultError::VaultPaused);
 
     // Unpause and deposit more
     client.set_paused(&false);
@@ -74,4 +101,64 @@ fn test_vault_deposit_flow() {
     assert_eq!(token_client.balance(&user), 300);
     assert_eq!(token_client.balance(&contract_id), 700);
     assert_eq!(client.get_position_balance(&user, &token_contract_id), 700);
+}
+
+#[test]
+fn test_pause_requires_admin_auth_emits_event_and_rejects_double_pause() {
+    let env = Env::default();
+
+    let (contract_id, client, admin) = setup_vault_with_stored_admin(&env);
+    let non_admin = Address::generate(&env);
+
+    let res = client
+        .mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "pause",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_pause();
+    assert!(res.is_err(), "non-admin should not be able to pause");
+    assert!(!env.as_contract(&contract_id, || storage::is_paused(&env)));
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "pause",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .pause();
+
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (event_contract, topics, data) = events.get(0).unwrap();
+    assert_eq!(event_contract, contract_id);
+    assert_eq!(topics.len(), 1);
+
+    let topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic, symbol_short!("paused"));
+
+    let data: Map<Symbol, Val> = data.try_into_val(&env).unwrap();
+    let by: Address = data
+        .get(symbol_short!("by"))
+        .unwrap()
+        .try_into_val(&env)
+        .unwrap();
+    assert_eq!(by, admin);
+    assert!(env.as_contract(&contract_id, || storage::is_paused(&env)));
+
+    env.mock_all_auths();
+    let err = client.try_pause().unwrap_err().unwrap();
+    assert_eq!(
+        VaultError::try_from(err).unwrap(),
+        VaultError::AlreadyPaused,
+        "double-pause should panic with a clear contract error"
+    );
 }


### PR DESCRIPTION
Closes #477

## Summary
- Added `pause(env: Env)` for admin-only emergency vault pausing.
- Persistently sets `Paused = true` and emits `Paused { by: admin }`.
- Added double-pause protection with a clear `AlreadyPaused` contract error.
- Ensured `deposit` and `withdraw` reject calls while paused.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`
- `stellar contract build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault pause operations now require admin authorization
  * Double-pausing is prevented; duplicate pause attempts return AlreadyPaused error
  * Withdrawals are blocked when vault is in paused state
  * Pause operations emit events with initiator address for audit tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alien-Protocol/Alien-Protocol/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->