### PR TITLE
fix: correct CI workflow configuration for Soroban contracts

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -14,52 +14,58 @@ jobs:
     name: Format, Lint & Cargo Check
     runs-on: ubuntu-latest
 
-
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-        targets: wasm32-unknown-unknown
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32v1-none
 
-    - name: Check formatting
-      run: cargo fmt --all --check
+      - name: Check formatting
+        run: cargo fmt --all --check
 
-    - name: Run Clippy lints
-      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Run Clippy lints
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-    - name: Cargo check
-      run: cargo check --verbose
+      - name: Cargo check
+        run: cargo check --verbose
 
-  build-and-test:
-    name: Build & Test
+  build:
+    name: Build Contracts (wasm32v1-none)
     runs-on: ubuntu-latest
     needs: checks
 
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Build Soroban contracts
+        run: |
+          cargo build \
+            -p collateral-vault \
+            -p lending-pool \
+            -p liquidation-engine \
+            -p oracle-adapter \
+            --target wasm32v1-none \
+            --release \
+            --verbose
+
+  test:
+    name: Run Tests (native)
+    runs-on: ubuntu-latest
+    needs: checks
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-        targets: wasm32-unknown-unknown
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Build Soroban contracts (wasm32-unknown-unknown)
-      run: |
-        cargo build \
-          -p collateral-vault \
-          -p lending-pool \
-          -p liquidation-engine \
-          -p oracle-adapter \
-          -p shared \
-          --target wasm32-unknown-unknown \
-          --release \
-          --verbose
-
-    - name: Run Cargo tests
-      run: cargo test --workspace --all-features --verbose
+      - name: Run Cargo tests
+        run: cargo test --workspace --all-features --verbose

--- a/contracts/shared/Cargo.toml
+++ b/contracts/shared/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
## Summary

Fixes #467 — CI workflow configuration errors blocking automated checks.

## Changes

### `.github/workflows/contract.yml`
- Replaced `wasm32-unknown-unknown` with `wasm32v1-none` target — required by `soroban-sdk` v23, which dropped support for the old target
- Split the `build-and-test` job into separate `build` and `test` jobs — Soroban testutils run on the native host, not under a wasm target, so combining them caused tests to fail or be silently skipped
- Removed `shared` from the explicit wasm build step — it is a library dependency, not a deployable contract, and gets compiled automatically as a dependency

### `contracts/shared/Cargo.toml`
- Removed `cdylib` from `crate-type` — `shared` is a pure library used as a dependency by other contracts, not a standalone deployable wasm binary

## Testing
- `cargo fmt --all --check` passes
- `cargo clippy --workspace --all-targets --all-features` passes
- `cargo build -p collateral-vault -p lending-pool -p liquidation-engine -p oracle-adapter --target wasm32v1-none --release` builds successfully
- `cargo test --workspace --all-features` passes on native target


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved continuous integration workflow by separating build and test operations with enhanced code quality checks including formatting validation and linting under optimized compilation targets.
* Refined build configuration for the shared contracts package to streamline library compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alien-Protocol/Alien-Protocol/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->