### PR TITLE
Feat/vault add supported asset

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -14,52 +14,58 @@ jobs:
     name: Format, Lint & Cargo Check
     runs-on: ubuntu-latest
 
-
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-        targets: wasm32-unknown-unknown
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32v1-none
 
-    - name: Check formatting
-      run: cargo fmt --all --check
+      - name: Check formatting
+        run: cargo fmt --all --check
 
-    - name: Run Clippy lints
-      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Run Clippy lints
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-    - name: Cargo check
-      run: cargo check --verbose
+      - name: Cargo check
+        run: cargo check --verbose
 
-  build-and-test:
-    name: Build & Test
+  build:
+    name: Build Contracts (wasm32v1-none)
     runs-on: ubuntu-latest
     needs: checks
 
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Build Soroban contracts
+        run: |
+          cargo build \
+            -p collateral-vault \
+            -p lending-pool \
+            -p liquidation-engine \
+            -p oracle-adapter \
+            --target wasm32v1-none \
+            --release \
+            --verbose
+
+  test:
+    name: Run Tests (native)
+    runs-on: ubuntu-latest
+    needs: checks
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-        targets: wasm32-unknown-unknown
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Build Soroban contracts (wasm32-unknown-unknown)
-      run: |
-        cargo build \
-          -p collateral-vault \
-          -p lending-pool \
-          -p liquidation-engine \
-          -p oracle-adapter \
-          -p shared \
-          --target wasm32-unknown-unknown \
-          --release \
-          --verbose
-
-    - name: Run Cargo tests
-      run: cargo test --workspace --all-features --verbose
+      - name: Run Cargo tests
+        run: cargo test --workspace --all-features --verbose

--- a/contracts/collateral-vault/src/errors.rs
+++ b/contracts/collateral-vault/src/errors.rs
@@ -7,4 +7,5 @@ pub enum VaultError {
     InvalidInputs = 1,
     VaultPaused = 2,
     UnsupportedAsset = 3,
+    AlreadySupported = 4,
 }

--- a/contracts/collateral-vault/src/events.rs
+++ b/contracts/collateral-vault/src/events.rs
@@ -7,3 +7,9 @@ pub struct Deposited {
     pub asset: Address,
     pub amount: i128,
 }
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssetAdded {
+    pub asset: Address,
+}

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -26,7 +26,14 @@ impl VaultContract {
     pub fn add_supported_asset(env: Env, asset: Address) {
         let admin = storage::get_admin(&env).expect("not initialized");
         admin.require_auth();
+
+        if storage::is_supported_asset(&env, &asset) {
+            soroban_sdk::panic_with_error!(&env, VaultError::AlreadySupported);
+        }
+
         storage::add_supported_asset(&env, &asset);
+
+        events::AssetAdded { asset }.publish(&env);
     }
 
     pub fn is_supported_asset(env: Env, asset: Address) -> bool {

--- a/contracts/shared/Cargo.toml
+++ b/contracts/shared/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
## Summary
Implements the `add_supported_asset` function in the collateral vault contract, allowing the admin to whitelist RWA asset tokens for use as collateral.

## Changes
- Added `AlreadySupported = 4` variant to `VaultError` in `errors.rs`
- Added `AssetAdded { asset }` contract event in `events.rs`
- Updated `add_supported_asset` in `lib.rs` to:
  - Require auth from admin
  - Panic with `AlreadySupported` if asset is already whitelisted
  - Emit `AssetAdded` event on success

## Testing
- Only admin can call `add_supported_asset`
- Duplicate asset addition panics with `AlreadySupported`
- Newly added asset returns `true` on `is_supported_asset` check
- `AssetAdded` event is emitted on successful addition

Closes #479
