### PR TITLE
feat(collateral-vault): implement get_position read-only view

### DIFF
--- a/contracts/collateral-vault/src/errors.rs
+++ b/contracts/collateral-vault/src/errors.rs
@@ -7,4 +7,5 @@ pub enum VaultError {
     InvalidInputs = 1,
     VaultPaused = 2,
     UnsupportedAsset = 3,
+    NoPosition = 4,
 }

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -2,6 +2,7 @@
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
 
 use errors::VaultError;
+use types::Position;
 
 #[contract]
 pub struct VaultContract;
@@ -67,6 +68,13 @@ impl VaultContract {
         let new_balance = balance + amount;
         storage::set_position_balance(&env, &user, &asset, new_balance);
 
+        // Keep the aggregated UserPosition record in sync.
+        let position = Position {
+            user: user.clone(),
+            amount: new_balance,
+        };
+        storage::set_user_position(&env, &position);
+
         storage::add_to_position_index(&env, &user);
 
         events::Deposited {
@@ -83,7 +91,15 @@ impl VaultContract {
 
     pub fn is_withdrawal_safe(_env: &Env, _user: Address, _amount: i128) {}
 
-    pub fn get_position(_env: &Env, _user: Address) {}
+    /// Returns the stored collateral `Position` for `user`.
+    /// Panics with `VaultError::NoPosition` if no entry is found.
+    /// Read-only — no authentication required, no state mutation.
+    pub fn get_position(env: Env, user: Address) -> Position {
+        match storage::get_user_position(&env, &user) {
+            Some(position) => position,
+            None => soroban_sdk::panic_with_error!(&env, VaultError::NoPosition),
+        }
+    }
 
     pub fn get_collateral_value(_env: &Env, _user: Address) {}
 }

--- a/contracts/collateral-vault/src/storage.rs
+++ b/contracts/collateral-vault/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::types::DataKey;
+use crate::types::{DataKey, Position};
 use soroban_sdk::{Address, Env, Vec};
 
 pub fn get_admin(env: &Env) -> Option<Address> {
@@ -61,4 +61,19 @@ pub fn add_to_position_index(env: &Env, user: &Address) {
             .persistent()
             .set(&DataKey::PositionIndex, &index);
     }
+}
+
+/// Retrieve the aggregated `Position` for `user`.
+/// Returns `None` if the user has no recorded position.
+pub fn get_user_position(env: &Env, user: &Address) -> Option<Position> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserPosition(user.clone()))
+}
+
+/// Persist an aggregated `Position` record for `user`.
+pub fn set_user_position(env: &Env, position: &Position) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserPosition(position.user.clone()), position);
 }

--- a/contracts/collateral-vault/src/test.rs
+++ b/contracts/collateral-vault/src/test.rs
@@ -75,3 +75,51 @@ fn test_vault_deposit_flow() {
     assert_eq!(token_client.balance(&contract_id), 700);
     assert_eq!(client.get_position_balance(&user, &token_contract_id), 700);
 }
+
+#[test]
+fn test_get_position_returns_correct_data() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin, &oracle);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_contract_id = token_contract.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+
+    token_admin_client.mint(&user, &1000);
+    client.add_supported_asset(&token_contract_id);
+    client.deposit(&user, &token_contract_id, &750);
+
+    // get_position should return the stored Position
+    let pos = client.get_position(&user);
+    assert_eq!(pos.user, user);
+    assert_eq!(pos.amount, 750);
+}
+
+#[test]
+#[should_panic]
+fn test_get_position_panics_with_no_position() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    client.initialize(&admin, &oracle);
+
+    // Should panic with NoPosition because stranger never deposited
+    client.get_position(&stranger);
+}

--- a/contracts/collateral-vault/src/types.rs
+++ b/contracts/collateral-vault/src/types.rs
@@ -8,4 +8,13 @@ pub enum DataKey {
     SupportedAsset(Address),
     Position(Address, Address), // (user, asset)
     PositionIndex,
+    UserPosition(Address),      // whole-position record keyed by user
+}
+
+/// Aggregated collateral position for a single user.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Position {
+    pub user: Address,
+    pub amount: i128,
 }


### PR DESCRIPTION
Closes #474

## Summary
Implements the `get_position(env: Env, user: Address) -> Position` read-only
function on the collateral vault contract.

## Changes
- errors.rs  → NoPosition = 4 added to VaultError
- types.rs   → Position struct + UserPosition(Address) DataKey
- storage.rs → get_user_position / set_user_position helpers
- lib.rs     → deposit syncs UserPosition; get_position fully implemented
- test.rs    → 2 new tests (happy path + NoPosition panic)

## Test Results
3 passed; 0 failed; 0 ignored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now retrieve their collateral position details
  * System tracks and stores aggregated position data for each user during deposits

* **Tests**
  * Added tests validating position retrieval functionality and proper error handling when positions don't exist

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alien-Protocol/Alien-Protocol/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->