### PR TITLE
feat(oracle-adapter): initialize contract storage layout [#507]

### DIFF
--- a/contracts/oracle-adapter/src/events.rs
+++ b/contracts/oracle-adapter/src/events.rs
@@ -1,0 +1,8 @@
+use soroban_sdk::{contractevent, Address};
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Initialized {
+    pub admin: Address,
+    pub staleness_threshold: u64,
+}

--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -1,25 +1,49 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contractimpl, Address, Env};
 
-#[contracttype]
-#[derive(Clone, Debug, PartialEq)]
-pub struct PriceData {
-    pub price: i128,
-    pub timestamp: u64,
-}
+mod events;
+mod storage;
+mod types;
+
+pub use types::{DataKey, PriceData};
 
 #[contract]
 pub struct OracleContract;
 
 #[contractimpl]
 impl OracleContract {
+    /// One-time setup: store admin and staleness threshold, emit Initialized event.
+    /// Panics with "AlreadyInitialized" if called more than once.
+    pub fn initialize(env: Env, admin: Address, staleness_threshold: u64) {
+        if storage::is_initialized(&env) {
+            panic!("AlreadyInitialized");
+        }
+        storage::set_admin(&env, &admin);
+        storage::set_staleness_threshold(&env, staleness_threshold);
+        events::Initialized {
+            admin,
+            staleness_threshold,
+        }
+        .publish(&env);
+    }
+
     pub fn get_price(env: Env, asset: Address) -> Option<PriceData> {
-        env.storage().persistent().get(&asset)
+        storage::get_price(&env, &asset)
     }
 
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
-        let price_data = PriceData { price, timestamp };
-        env.storage().persistent().set(&asset, &price_data);
+        let caller = storage::get_admin(&env).expect("NotInitialized");
+        caller.require_auth();
+        let data = PriceData { price, timestamp };
+        storage::set_price(&env, &asset, &data);
+    }
+
+    pub fn get_admin(env: Env) -> Option<Address> {
+        storage::get_admin(&env)
+    }
+
+    pub fn get_staleness_threshold(env: Env) -> Option<u64> {
+        storage::get_staleness_threshold(&env)
     }
 }
 

--- a/contracts/oracle-adapter/src/storage.rs
+++ b/contracts/oracle-adapter/src/storage.rs
@@ -11,9 +11,7 @@ pub fn set_admin(env: &Env, admin: &Address) {
 }
 
 pub fn get_staleness_threshold(env: &Env) -> Option<u64> {
-    env.storage()
-        .instance()
-        .get(&DataKey::StalenessThreshold)
+    env.storage().instance().get(&DataKey::StalenessThreshold)
 }
 
 pub fn set_staleness_threshold(env: &Env, threshold: u64) {

--- a/contracts/oracle-adapter/src/storage.rs
+++ b/contracts/oracle-adapter/src/storage.rs
@@ -1,0 +1,39 @@
+use soroban_sdk::{Address, Env};
+
+use crate::types::{DataKey, PriceData};
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::Admin)
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_staleness_threshold(env: &Env) -> Option<u64> {
+    env.storage()
+        .instance()
+        .get(&DataKey::StalenessThreshold)
+}
+
+pub fn set_staleness_threshold(env: &Env, threshold: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::StalenessThreshold, &threshold);
+}
+
+pub fn get_price(env: &Env, asset: &Address) -> Option<PriceData> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Price(asset.clone()))
+}
+
+pub fn set_price(env: &Env, asset: &Address, data: &PriceData) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Price(asset.clone()), data);
+}
+
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}

--- a/contracts/oracle-adapter/src/test.rs
+++ b/contracts/oracle-adapter/src/test.rs
@@ -1,4 +1,73 @@
 #![cfg(test)]
 
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{OracleContract, OracleContractClient};
+
+fn setup() -> (Env, OracleContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(OracleContract, ());
+    let client = OracleContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    (env, client, admin)
+}
+
 #[test]
-fn test() {}
+fn test_initialize_stores_admin_and_threshold() {
+    let (_, client, admin) = setup();
+    client.initialize(&admin, &3600);
+    assert_eq!(client.get_admin(), Some(admin));
+    assert_eq!(client.get_staleness_threshold(), Some(3600));
+}
+
+#[test]
+#[should_panic(expected = "AlreadyInitialized")]
+fn test_initialize_panics_if_called_twice() {
+    let (_, client, admin) = setup();
+    client.initialize(&admin, &3600);
+    client.initialize(&admin, &3600);
+}
+
+#[test]
+fn test_get_price_returns_none_before_set() {
+    let (env, client, admin) = setup();
+    client.initialize(&admin, &3600);
+    let asset = Address::generate(&env);
+    assert_eq!(client.get_price(&asset), None);
+}
+
+#[test]
+fn test_set_and_get_price() {
+    let (env, client, admin) = setup();
+    client.initialize(&admin, &3600);
+    let asset = Address::generate(&env);
+    client.set_price(&asset, &1_500_000_000, &1_000_000);
+    let data = client.get_price(&asset).unwrap();
+    assert_eq!(data.price, 1_500_000_000);
+    assert_eq!(data.timestamp, 1_000_000);
+}
+
+#[test]
+fn test_set_price_overwrites_existing() {
+    let (env, client, admin) = setup();
+    client.initialize(&admin, &3600);
+    let asset = Address::generate(&env);
+    client.set_price(&asset, &100, &1);
+    client.set_price(&asset, &200, &2);
+    let data = client.get_price(&asset).unwrap();
+    assert_eq!(data.price, 200);
+    assert_eq!(data.timestamp, 2);
+}
+
+#[test]
+fn test_multiple_assets_independent() {
+    let (env, client, admin) = setup();
+    client.initialize(&admin, &3600);
+    let asset_a = Address::generate(&env);
+    let asset_b = Address::generate(&env);
+    client.set_price(&asset_a, &1_000, &10);
+    client.set_price(&asset_b, &2_000, &20);
+    assert_eq!(client.get_price(&asset_a).unwrap().price, 1_000);
+    assert_eq!(client.get_price(&asset_b).unwrap().price, 2_000);
+}

--- a/contracts/oracle-adapter/src/types.rs
+++ b/contracts/oracle-adapter/src/types.rs
@@ -1,0 +1,17 @@
+#![allow(unused)]
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PriceData {
+    pub price: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Price(Address),
+    Admin,
+    StalenessThreshold,
+}


### PR DESCRIPTION
## Summary

Implements the foundational storage layout for the Oracle Adapter module as specified in #507.

- Defines `DataKey` enum (`Price(Address)`, `Admin`, `StalenessThreshold`) in `types.rs`
- Creates `storage.rs` with typed read/write/check helpers for all three keys
- Implements `initialize(admin, staleness_threshold)` with a one-time storage-presence guard (panics `AlreadyInitialized` on second call)
- Emits `Initialized` contract event (via `#[contractevent]`) on first call
- Moves `PriceData` to `types.rs`; gates `set_price` behind admin `require_auth()`

## Test output

```
running 6 tests
test test::test_initialize_stores_admin_and_threshold ... ok
test test::test_initialize_panics_if_called_twice - should panic ... ok
test test::test_get_price_returns_none_before_set ... ok
test test::test_multiple_assets_independent ... ok
test test::test_set_and_get_price ... ok
test test::test_set_price_overwrites_existing ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

Closes #507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contract now requires one-time initialization with an admin address and staleness threshold.
  * Added ability to query the configured admin address and staleness threshold values.
  * Price updates now require admin authorization for enhanced access control.
  * Initialization event is emitted on successful contract setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->