### PR TITLE
feat(collateral-vault): implement pause function with Paused { by: ad…

### DIFF
--- a/contracts/collateral-vault/src/errors.rs
+++ b/contracts/collateral-vault/src/errors.rs
@@ -15,4 +15,5 @@ pub enum VaultError {
     NotInitialized = 9,
     BelowMinCollateralRatio = 10,
     AlreadyAdmin = 11,
+    AlreadyPaused = 12,
 }

--- a/contracts/collateral-vault/src/events.rs
+++ b/contracts/collateral-vault/src/events.rs
@@ -30,7 +30,7 @@ pub struct AdminChanged {
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Paused {
-    pub paused: bool,
+    pub by: Address,
 }
 
 #[contractevent]

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -62,12 +62,12 @@ impl VaultContract {
         admin.require_auth();
 
         if storage::is_paused(&env) {
-            panic!("already paused");
+            soroban_sdk::panic_with_error!(&env, VaultError::AlreadyPaused);
         }
 
         storage::set_paused(&env, true);
 
-        events::Paused { paused: true }.publish(&env);
+        events::Paused { by: admin }.publish(&env);
     }
 
     pub fn unpause(env: Env) {

--- a/contracts/collateral-vault/test_snapshots/tests/test_admin/test_old_admin_cannot_act_after_transfer.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_admin/test_old_admin_cannot_act_after_transfer.1.json
@@ -693,10 +693,10 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "paused"
+                    "symbol": "by"
                   },
                   "val": {
-                    "bool": true
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                   }
                 }
               ]

--- a/contracts/collateral-vault/test_snapshots/tests/test_admin/test_pause_success.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_admin/test_pause_success.1.json
@@ -641,10 +641,10 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "paused"
+                    "symbol": "by"
                   },
                   "val": {
-                    "bool": true
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                   }
                 }
               ]


### PR DESCRIPTION
Closes #477

---

…min } event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for vault pause operations with a specific error code for already-paused scenarios.

* **New Features**
  * Pause events now record the address of the account that initiated the pause, providing better audit trail visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->