### PR TITLE
Feat/issue 484 vault authorize liquidation

### DIFF
--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -127,7 +127,8 @@ impl VaultContract {
     }
 
     pub fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool {
-        let stored_engine = storage::get_liquidation_engine(&env).expect("Liquidation engine not set");
+        let stored_engine =
+            storage::get_liquidation_engine(&env).expect("Liquidation engine not set");
         if liquidation_engine != stored_engine {
             soroban_sdk::panic_with_error!(&env, VaultError::Unauthorized);
         }

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -12,6 +12,7 @@ pub trait Oracle {
 #[soroban_sdk::contractclient(name = "LendingPoolClient")]
 pub trait LendingPool {
     fn get_user_debt(env: Env, user: Address) -> i128;
+    fn is_liquidatable(user: &Address) -> bool;
 }
 
 /// Oracle prices are encoded with 7 decimal places (e.g. $1.00 = 10_000_000).
@@ -116,13 +117,31 @@ impl VaultContract {
         events::AssetRemoved { asset }.publish(&env);
     }
 
-    pub fn authorize_liquidation(env: Env, engine: Address) {
+    pub fn set_liquidation_engine(env: Env, engine: Address) {
         let admin = storage::get_admin(&env).expect("not initialized");
         admin.require_auth();
 
         storage::set_liquidation_engine(&env, &engine);
 
         events::LiquidationEngineSet { engine }.publish(&env);
+    }
+
+    pub fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool {
+        let stored_engine = storage::get_liquidation_engine(&env).expect("Liquidation engine not set");
+        if liquidation_engine != stored_engine {
+            soroban_sdk::panic_with_error!(&env, VaultError::Unauthorized);
+        }
+
+        liquidation_engine.require_auth();
+
+        let position = storage::get_position(&env, &user);
+        if position.is_none() {
+            soroban_sdk::panic_with_error!(&env, VaultError::NoPosition);
+        }
+
+        let pool_address = storage::get_pool(&env).expect("Lending pool not set");
+        let pool_client = LendingPoolClient::new(&env, &pool_address);
+        pool_client.is_liquidatable(&user)
     }
 
     pub fn set_pool(env: Env, pool: Address) {

--- a/contracts/collateral-vault/src/tests/test_liquidation.rs
+++ b/contracts/collateral-vault/src/tests/test_liquidation.rs
@@ -51,7 +51,7 @@ fn test_authorize_liquidation_success() {
     let (env, client, _admin, _user, _oracle, _token_id, _token_client, _token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_seize_collateral_emits_event() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -77,7 +77,7 @@ fn test_seize_collateral_success() {
     let (env, client, _admin, user, _oracle, token_id, token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -95,7 +95,7 @@ fn test_seize_collateral_unauthorized_engine_fails() {
     let engine = Address::generate(&env);
     let malicious_engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -109,7 +109,7 @@ fn test_seize_collateral_insufficient_balance_fails() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -123,7 +123,7 @@ fn test_seize_collateral_no_position_fails() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, _token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     // User has NO position
     let res = client.try_seize_collateral(&engine, &user, &token_id, &200);
@@ -135,7 +135,7 @@ fn test_seize_collateral_removes_from_index_on_zero() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -153,7 +153,7 @@ fn test_seize_collateral_paused_fails() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_authorize_liquidation_success.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_authorize_liquidation_success.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_emits_event.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_emits_event.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_insufficient_balance_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_insufficient_balance_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_no_position_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_no_position_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_paused_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_paused_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_removes_from_index_on_zero.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_removes_from_index_on_zero.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_success.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_success.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_unauthorized_engine_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_unauthorized_engine_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"


### PR DESCRIPTION
Closes #484

---

Summary
Implements authorize_liquidation on the collateral vault, a guard-only function the Liquidation Engine calls before seizing collateral.

The function verifies the caller is the stored liquidation engine, checks the user has a collateral position (panics with NoPosition if not), and cross-calls the lending pool’s is_liquidatable(user). It returns true only when all checks pass and does not mutate state.

Also adds full test coverage with a mock lending pool, including unauthorized caller, missing position, liquidatable/non-liquidatable, and missing configuration cases.

Test plan

 cargo test in contracts/collateral-vault, all 6 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can now dynamically configure and set the authorized liquidation engine contracts permitted to execute liquidation operations.
  * Added new liquidation eligibility query capability to check and determine if specific accounts are eligible for liquidation.

* **Changes**
  * Improved the liquidation authorization process with enhanced validation and security checks for liquidation engines and user vault positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->