### PR TITLE
feat(collateral-vault): implement get_collateral_value with PRICE_PRECISION

### DIFF
--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -14,6 +14,13 @@ pub trait LendingPool {
     fn get_user_debt(env: Env, user: Address) -> i128;
 }
 
+/// Oracle prices are encoded with 7 decimal places (e.g. $1.00 = 10_000_000).
+/// Dividing `amount * price` by this constant yields the USD-denominated value.
+const PRICE_PRECISION: i128 = 10_000_000;
+
+/// Maximum age (in seconds) an oracle price may have before it is considered stale.
+const ORACLE_STALE_THRESHOLD: u64 = 300;
+
 #[contract]
 pub struct VaultContract;
 
@@ -296,9 +303,12 @@ impl VaultContract {
         let oracle_client = OracleClient::new(&env, &oracle_address);
         let price_data = oracle_client.get_price(&asset).expect("price not found");
 
+        // Apply the same PRICE_PRECISION scaling used by get_collateral_value so
+        // that withdrawn_value is denominated in USD and comparable to total_value.
         let withdrawn_value = amount
             .checked_mul(price_data.price)
-            .unwrap_or_else(|| panic!("overflow in withdrawn value calculation"));
+            .unwrap_or_else(|| panic!("overflow in withdrawn value calculation"))
+            / PRICE_PRECISION;
 
         if total_value < withdrawn_value {
             return false;
@@ -325,13 +335,11 @@ impl VaultContract {
 
         let mut total_value: i128 = 0;
         let current_time = env.ledger().timestamp();
-        const ORACLE_STALE_THRESHOLD: u64 = 300; // 5 minutes
 
         for item in position.collateral.iter() {
-            let price_opt = oracle_client.get_price(&item.asset);
-            let price_data = match price_opt {
+            let price_data = match oracle_client.get_price(&item.asset) {
                 Some(pd) => pd,
-                None => panic!("price not found"),
+                None => soroban_sdk::panic_with_error!(&env, VaultError::AssetNotFound),
             };
 
             if current_time > price_data.timestamp
@@ -340,10 +348,13 @@ impl VaultContract {
                 soroban_sdk::panic_with_error!(&env, VaultError::StalePrice);
             }
 
+            // Compute USD value: amount * price / PRICE_PRECISION.
+            // checked_mul guards against overflow before the safe integer division.
             let item_value = item
                 .amount
                 .checked_mul(price_data.price)
-                .unwrap_or_else(|| panic!("overflow in value calculation"));
+                .unwrap_or_else(|| panic!("overflow in value calculation"))
+                / PRICE_PRECISION;
 
             total_value = total_value
                 .checked_add(item_value)

--- a/contracts/collateral-vault/src/tests/test_read_functions.rs
+++ b/contracts/collateral-vault/src/tests/test_read_functions.rs
@@ -114,11 +114,12 @@ fn test_get_collateral_value_correct_calculation() {
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
 
-    // Mock price: $10 (10000000 with 7 decimals) at timestamp 1000
+    // Price: $10.00 encoded as 10_000_000 (7-decimal oracle format).
+    // USD value = 500 * 10_000_000 / 10_000_000 = 500.
     oracle.set_price(&token_id, &10_000_000, &1000);
 
     let val = client.get_collateral_value(&user);
-    assert_eq!(val, 500 * 10_000_000);
+    assert_eq!(val, 500);
 }
 
 #[test]
@@ -150,17 +151,17 @@ fn test_get_collateral_value_stale_price_panics() {
 fn test_get_collateral_value_precision() {
     let (_env, client, _admin, user, token_id, _token_client, token_admin, _, oracle) = setup_env();
 
-    // Large deposit amount
+    // 10^12 units at a price of $100 (1_000_000_000 in 7-decimal format).
+    // USD value = 10^12 * 10^9 / 10^7 = 10^14.
     let large_amount = 1_000_000_000_000_i128;
     token_admin.mint(&user, &large_amount);
     client.deposit(&user, &token_id, &large_amount);
 
-    // Large price
     let large_price = 1_000_000_000_i128;
     oracle.set_price(&token_id, &large_price, &1000);
 
     let val = client.get_collateral_value(&user);
-    assert_eq!(val, large_amount * large_price);
+    assert_eq!(val, 100_000_000_000_000_i128); // 10^14
 }
 
 #[test]
@@ -170,13 +171,13 @@ fn test_get_collateral_value_uses_latest_price() {
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
 
-    // First price
+    // $10.00 price → 500 * 10_000_000 / 10_000_000 = $500
     oracle.set_price(&token_id, &10_000_000, &1000);
-    assert_eq!(client.get_collateral_value(&user), 500 * 10_000_000);
+    assert_eq!(client.get_collateral_value(&user), 500);
 
-    // Updated price
+    // $12.00 price → 500 * 12_000_000 / 10_000_000 = $600
     oracle.set_price(&token_id, &12_000_000, &1000);
-    assert_eq!(client.get_collateral_value(&user), 500 * 12_000_000);
+    assert_eq!(client.get_collateral_value(&user), 600);
 }
 
 #[test]
@@ -191,4 +192,26 @@ fn test_get_position_after_full_withdraw_panics() {
 
     let res = client.try_get_position(&user);
     assert!(res.is_err(), "should panic after full withdrawal");
+}
+
+/// Verifies that PRICE_PRECISION (10_000_000) is applied so that the returned
+/// value is denominated in USD rather than raw (amount × raw_price) units.
+#[test]
+fn test_get_collateral_value_price_precision_applied() {
+    let (_env, client, _admin, user, token_id, _token_client, token_admin, _, oracle) = setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &1);
+
+    // $1.00 encoded as 10_000_000; 1 unit × $1.00 = $1 (i.e. 1, not 10_000_000).
+    oracle.set_price(&token_id, &10_000_000, &1000);
+    assert_eq!(client.get_collateral_value(&user), 1);
+
+    // $0.50 encoded as 5_000_000; 1 unit × $0.50 = 0 (integer floor).
+    oracle.set_price(&token_id, &5_000_000, &1000);
+    assert_eq!(client.get_collateral_value(&user), 0);
+
+    // $2.00 encoded as 20_000_000; 1 unit × $2.00 = $2.
+    oracle.set_price(&token_id, &20_000_000, &1000);
+    assert_eq!(client.get_collateral_value(&user), 2);
 }

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -195,16 +195,17 @@ fn test_withdraw_collateral_ratio_check() {
     let (_env, client, _admin, user, _token_client, token_admin, pool, oracle, token_id) =
         setup_env();
 
-    // 1 token = 1USD (10^7 decimals)
+    // Price: $1.00 encoded as 10_000_000 (7-decimal oracle format).
+    // 500 tokens → collateral_value = 500 * 10_000_000 / PRICE_PRECISION = $500 USD.
     oracle.set_price(&token_id, &10_000_000, &1000);
 
     token_admin.mint(&user, &1000);
-    client.deposit(&user, &token_id, &500); // Value: 500 * 10^7
+    client.deposit(&user, &token_id, &500);
 
-    // Set debt to 400 * 10^7.
-    // Remaining value if we withdraw 101: 399 * 10^7.
-    // 399 >= 400 * 1.1 (440)? No.
-    pool.set_user_debt(&4_000_000_000);
+    // Debt is denominated in USD (same unit as collateral_value after PRICE_PRECISION).
+    // debt = $400.  Minimum required collateral = 400 * 110 / 100 = $440.
+    // Withdrawing 101 → remaining = 500 − 101 = $399 < $440 → blocked.
+    pool.set_user_debt(&400);
 
     let res = client.try_withdraw(&user, &token_id, &101);
     assert!(
@@ -212,7 +213,7 @@ fn test_withdraw_collateral_ratio_check() {
         "should block withdrawal that reduces ratio below 110%"
     );
 
-    // Withdrawing 50 should leave 450. 450 >= 440. Success.
+    // Withdrawing 50 → remaining = 500 − 50 = $450 ≥ $440 → allowed.
     client.withdraw(&user, &token_id, &50);
     assert_eq!(client.get_position_balance(&user, &token_id), 450);
 }

--- a/contracts/collateral-vault/test_snapshots/tests/test_read_functions/test_get_collateral_value_price_precision_applied.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_read_functions/test_get_collateral_value_price_precision_applied.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 7,
+    "address": 6,
     "nonce": 0,
     "mux_id": 0
   },
@@ -67,28 +67,6 @@
         }
       ]
     ],
-    [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_pool",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [],
-    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
@@ -127,7 +105,7 @@
                   "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
                 },
                 {
-                  "i128": "500"
+                  "i128": "1"
                 }
               ]
             }
@@ -146,7 +124,7 @@
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                     },
                     {
-                      "i128": "500"
+                      "i128": "1"
                     }
                   ]
                 }
@@ -159,31 +137,9 @@
     ],
     [],
     [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "withdraw",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                {
-                  "i128": "50"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
+    [],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -381,45 +337,6 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "Pool"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Pool"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
                   "symbol": "Position"
                 },
                 {
@@ -455,7 +372,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "i128": "450"
+                  "i128": "1"
                 }
               }
             },
@@ -704,7 +621,7 @@
                         "symbol": "price"
                       },
                       "val": {
-                        "i128": "10000000"
+                        "i128": "20000000"
                       }
                     },
                     {
@@ -825,106 +742,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": "4837995959683129791"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "4837995959683129791"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": "4270020994084947596"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "4270020994084947596"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": "6277191135259896685"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "6277191135259896685"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
               "ledger_key_nonce": {
                 "nonce": "2032731177588607455"
@@ -939,7 +757,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "2032731177588607455"
@@ -957,11 +775,13 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
-              "string": "debt"
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
             },
-            "durability": "persistent"
+            "durability": "temporary"
           }
         },
         [
@@ -970,51 +790,19 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
-                  "string": "debt"
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": "400"
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
-            "key": "ledger_key_contract_instance",
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
-                "key": "ledger_key_contract_instance",
-                "durability": "persistent",
-                "val": {
-                  "contract_instance": {
-                    "executable": {
-                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                    },
-                    "storage": null
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
                   }
-                }
+                },
+                "durability": "temporary",
+                "val": "void"
               }
             },
             "ext": "v0"
           },
-          4095
+          6311999
         ]
       ],
       [
@@ -1059,7 +847,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "450"
+                        "i128": "1"
                       }
                     },
                     {
@@ -1129,7 +917,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "550"
+                        "i128": "999"
                       }
                     },
                     {


### PR DESCRIPTION
## Summary

Closes #475

- Add module-level `PRICE_PRECISION = 10_000_000` and `ORACLE_STALE_THRESHOLD = 300` constants as a single source of truth for the contract.
- Fix `get_collateral_value` to compute `amount * price / PRICE_PRECISION`, returning the correct USD-denominated `i128` value (the core requirement of the issue).
- Replace bare `panic!("price not found")` with `soroban_sdk::panic_with_error!(AssetNotFound)` for consistent structured error propagation.
- Fix `is_withdrawal_safe` to apply the same `PRICE_PRECISION` division to `withdrawn_value`, so both sides of the collateral-ratio comparison are in USD and not mismatched units.
- Update three existing test assertions that were written against the pre-fix raw-units behaviour.
- Add `test_get_collateral_value_price_precision_applied` to explicitly verify the PRICE_PRECISION division at $1.00, $0.50, and $2.00 price points.

## Test plan

- [x] `cargo test -p collateral-vault` — all 65 tests pass
- [x] `get_collateral_value` returns correct USD value based on oracle price
- [x] Panics with `StalePrice` when oracle price is older than 300 s
- [x] Panics with `NoPosition` when user has no collateral
- [x] No integer overflow for expected asset ranges (`checked_mul` before division)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected USD-value calculations for collateral valuation and withdrawal safety checks to apply consistent decimal precision scaling.
  * Improved error handling to surface a clearer message when the oracle lacks price data for an asset.

* **Tests**
  * Updated test cases to reflect corrected precision handling in collateral valuations.
  * Added new test coverage for precision scaling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->