### PR TITLE
feat(collateral-vault): implement authorize_liquidation guard function

### DIFF
--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -127,7 +127,8 @@ impl VaultContract {
     }
 
     pub fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool {
-        let stored_engine = storage::get_liquidation_engine(&env).expect("Liquidation engine not set");
+        let stored_engine =
+            storage::get_liquidation_engine(&env).expect("Liquidation engine not set");
         if liquidation_engine != stored_engine {
             soroban_sdk::panic_with_error!(&env, VaultError::Unauthorized);
         }

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -12,6 +12,7 @@ pub trait Oracle {
 #[soroban_sdk::contractclient(name = "LendingPoolClient")]
 pub trait LendingPool {
     fn get_user_debt(env: Env, user: Address) -> i128;
+    fn is_liquidatable(user: &Address) -> bool;
 }
 
 /// Oracle prices are encoded with 7 decimal places (e.g. $1.00 = 10_000_000).
@@ -116,13 +117,31 @@ impl VaultContract {
         events::AssetRemoved { asset }.publish(&env);
     }
 
-    pub fn authorize_liquidation(env: Env, engine: Address) {
+    pub fn set_liquidation_engine(env: Env, engine: Address) {
         let admin = storage::get_admin(&env).expect("not initialized");
         admin.require_auth();
 
         storage::set_liquidation_engine(&env, &engine);
 
         events::LiquidationEngineSet { engine }.publish(&env);
+    }
+
+    pub fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool {
+        let stored_engine = storage::get_liquidation_engine(&env).expect("Liquidation engine not set");
+        if liquidation_engine != stored_engine {
+            soroban_sdk::panic_with_error!(&env, VaultError::Unauthorized);
+        }
+
+        liquidation_engine.require_auth();
+
+        let position = storage::get_position(&env, &user);
+        if position.is_none() {
+            soroban_sdk::panic_with_error!(&env, VaultError::NoPosition);
+        }
+
+        let pool_address = storage::get_pool(&env).expect("Lending pool not set");
+        let pool_client = LendingPoolClient::new(&env, &pool_address);
+        pool_client.is_liquidatable(&user)
     }
 
     pub fn set_pool(env: Env, pool: Address) {

--- a/contracts/collateral-vault/src/tests/test_liquidation.rs
+++ b/contracts/collateral-vault/src/tests/test_liquidation.rs
@@ -51,7 +51,7 @@ fn test_authorize_liquidation_success() {
     let (env, client, _admin, _user, _oracle, _token_id, _token_client, _token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_seize_collateral_emits_event() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -77,7 +77,7 @@ fn test_seize_collateral_success() {
     let (env, client, _admin, user, _oracle, token_id, token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -95,7 +95,7 @@ fn test_seize_collateral_unauthorized_engine_fails() {
     let engine = Address::generate(&env);
     let malicious_engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -109,7 +109,7 @@ fn test_seize_collateral_insufficient_balance_fails() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -123,7 +123,7 @@ fn test_seize_collateral_no_position_fails() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, _token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     // User has NO position
     let res = client.try_seize_collateral(&engine, &user, &token_id, &200);
@@ -135,7 +135,7 @@ fn test_seize_collateral_removes_from_index_on_zero() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
@@ -153,7 +153,7 @@ fn test_seize_collateral_paused_fails() {
     let (env, client, _admin, user, _oracle, token_id, _token_client, token_admin) = setup_env();
     let engine = Address::generate(&env);
 
-    client.authorize_liquidation(&engine);
+    client.set_liquidation_engine(&engine);
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_authorize_liquidation_success.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_authorize_liquidation_success.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_emits_event.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_emits_event.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_insufficient_balance_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_insufficient_balance_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_no_position_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_no_position_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_paused_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_paused_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_removes_from_index_on_zero.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_removes_from_index_on_zero.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_success.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_success.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"

--- a/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_unauthorized_engine_fails.1.json
+++ b/contracts/collateral-vault/test_snapshots/tests/test_liquidation/test_seize_collateral_unauthorized_engine_fails.1.json
@@ -73,7 +73,7 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "authorize_liquidation",
+              "function_name": "set_liquidation_engine",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"


### PR DESCRIPTION
- Add is_liquidatable method to LendingPool trait for cross-contract calls
- Rename existing authorize_liquidation to set_liquidation_engine (it was actually setting the engine address)
- Implement new authorize_liquidation guard function following spec:
  * Signature: fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool
  * Verifies caller matches stored LiquidationEngine address
  * Checks user has a position (panics with NoPosition if absent)
  * Cross-calls LendingPool to verify user is liquidatable
  * Returns true if all checks pass
  * Pure check with no state mutation
- Update tests to use set_liquidation_engine instead of old authorize_liquidation

Resolves #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new query functionality to check whether accounts are eligible for liquidation.

* **Updates**
  * Restructured liquidation engine configuration process to separate setup from authorization checks.
  * Enhanced verification flow for liquidation operations with improved authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->