### PR TITLE
feat(oracle-adapter): define oracle contract events for indexer (Clos…

### DIFF
--- a/contracts/oracle-adapter/src/events.rs
+++ b/contracts/oracle-adapter/src/events.rs
@@ -14,3 +14,28 @@ pub struct PriceUpdated {
     pub price: i128,
     pub timestamp: u64,
 }
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AdminChanged {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct StalenessThresholdUpdated {
+    pub threshold: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct FeederAdded {
+    pub feeder: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct FeederRemoved {
+    pub feeder: Address,
+}

--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contracterror, contractevent, contractimpl, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, Address, Env};
 
 #[contracterror]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7,13 +7,8 @@ use soroban_sdk::{contract, contracterror, contractevent, contractimpl, Address,
 pub enum OracleError {
     NotInitialized = 1,
     AlreadyAdmin = 2,
-}
-
-#[contractevent]
-#[derive(Clone, Debug, PartialEq)]
-pub struct AdminChanged {
-    pub old_admin: Address,
-    pub new_admin: Address,
+    AlreadyFeeder = 3,
+    NotFeeder = 4,
 }
 
 mod events;
@@ -89,6 +84,20 @@ impl OracleContract {
         storage::get_staleness_threshold(&env)
     }
 
+    pub fn set_staleness_threshold(env: Env, threshold: u64) {
+        let admin = match storage::get_admin(&env) {
+            Some(addr) => addr,
+            None => soroban_sdk::panic_with_error!(&env, OracleError::NotInitialized),
+        };
+        admin.require_auth();
+
+        assert!(threshold > 0, "threshold must be positive");
+
+        storage::set_staleness_threshold(&env, threshold);
+
+        events::StalenessThresholdUpdated { threshold }.publish(&env);
+    }
+
     pub fn set_admin(env: Env, new_admin: Address) {
         let current_admin = match storage::get_admin(&env) {
             Some(addr) => addr,
@@ -102,11 +111,43 @@ impl OracleContract {
 
         storage::set_admin(&env, &new_admin);
 
-        AdminChanged {
+        events::AdminChanged {
             old_admin: current_admin,
             new_admin,
         }
         .publish(&env);
+    }
+
+    pub fn add_feeder(env: Env, feeder: Address) {
+        let admin = match storage::get_admin(&env) {
+            Some(addr) => addr,
+            None => soroban_sdk::panic_with_error!(&env, OracleError::NotInitialized),
+        };
+        admin.require_auth();
+
+        if storage::has_feeder(&env, &feeder) {
+            soroban_sdk::panic_with_error!(&env, OracleError::AlreadyFeeder);
+        }
+
+        storage::add_feeder(&env, &feeder);
+
+        events::FeederAdded { feeder }.publish(&env);
+    }
+
+    pub fn remove_feeder(env: Env, feeder: Address) {
+        let admin = match storage::get_admin(&env) {
+            Some(addr) => addr,
+            None => soroban_sdk::panic_with_error!(&env, OracleError::NotInitialized),
+        };
+        admin.require_auth();
+
+        if !storage::has_feeder(&env, &feeder) {
+            soroban_sdk::panic_with_error!(&env, OracleError::NotFeeder);
+        }
+
+        storage::remove_feeder(&env, &feeder);
+
+        events::FeederRemoved { feeder }.publish(&env);
     }
 }
 

--- a/contracts/oracle-adapter/src/storage.rs
+++ b/contracts/oracle-adapter/src/storage.rs
@@ -35,3 +35,21 @@ pub fn set_price(env: &Env, asset: &Address, data: &PriceData) {
 pub fn is_initialized(env: &Env) -> bool {
     env.storage().instance().has(&DataKey::Admin)
 }
+
+pub fn has_feeder(env: &Env, feeder: &Address) -> bool {
+    env.storage()
+        .instance()
+        .has(&DataKey::Feeder(feeder.clone()))
+}
+
+pub fn add_feeder(env: &Env, feeder: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Feeder(feeder.clone()), &true);
+}
+
+pub fn remove_feeder(env: &Env, feeder: &Address) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::Feeder(feeder.clone()));
+}

--- a/contracts/oracle-adapter/src/test.rs
+++ b/contracts/oracle-adapter/src/test.rs
@@ -426,3 +426,124 @@ fn test_get_admin_requires_no_auth() {
     assert!(result.is_some());
     assert_eq!(result.unwrap(), admin);
 }
+
+// ── Issue #520: Oracle Contract Events ────────────────────────────────────────
+
+#[test]
+fn test_initialize_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(OracleContract, ());
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &300);
+
+    let last_event = env.events().all().last().unwrap();
+    assert_eq!(last_event.0, client.address);
+
+    let event_symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(event_symbol, Symbol::new(&env, "initialized"));
+}
+
+#[test]
+fn test_set_staleness_threshold_success() {
+    let (_env, client, _admin) = setup_env();
+
+    client.set_staleness_threshold(&600);
+
+    let updated = client.get_staleness_threshold();
+    assert_eq!(updated, Some(600));
+}
+
+#[test]
+fn test_set_staleness_threshold_emits_event() {
+    let (env, client, _admin) = setup_env();
+
+    client.set_staleness_threshold(&600);
+
+    let last_event = env.events().all().last().unwrap();
+    assert_eq!(last_event.0, client.address);
+
+    let event_symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(
+        event_symbol,
+        Symbol::new(&env, "staleness_threshold_updated")
+    );
+}
+
+#[test]
+fn test_set_staleness_threshold_unauthorized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(OracleContract, ());
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let result = client.try_set_staleness_threshold(&600);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::NotInitialized as u32)
+    );
+}
+
+#[test]
+fn test_add_feeder_success() {
+    let (env, client, _admin) = setup_env();
+
+    let feeder = Address::generate(&env);
+    client.add_feeder(&feeder);
+
+    // Last emitted event must be FeederAdded with our feeder
+    let last_event = env.events().all().last().unwrap();
+    assert_eq!(last_event.0, client.address);
+
+    let event_symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(event_symbol, Symbol::new(&env, "feeder_added"));
+}
+
+#[test]
+fn test_add_feeder_duplicate_fails() {
+    let (env, client, _admin) = setup_env();
+    let feeder = Address::generate(&env);
+    client.add_feeder(&feeder);
+
+    let result = client.try_add_feeder(&feeder);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::AlreadyFeeder as u32)
+    );
+}
+
+#[test]
+fn test_remove_feeder_success() {
+    let (env, client, _admin) = setup_env();
+    let feeder = Address::generate(&env);
+    client.add_feeder(&feeder);
+
+    client.remove_feeder(&feeder);
+
+    let last_event = env.events().all().last().unwrap();
+    assert_eq!(last_event.0, client.address);
+
+    let event_symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(event_symbol, Symbol::new(&env, "feeder_removed"));
+}
+
+#[test]
+fn test_remove_feeder_not_existing_fails() {
+    let (env, client, _admin) = setup_env();
+    let feeder = Address::generate(&env);
+
+    let result = client.try_remove_feeder(&feeder);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::NotFeeder as u32)
+    );
+}

--- a/contracts/oracle-adapter/src/types.rs
+++ b/contracts/oracle-adapter/src/types.rs
@@ -14,4 +14,5 @@ pub enum DataKey {
     Price(Address),
     Admin,
     StalenessThreshold,
+    Feeder(Address),
 }


### PR DESCRIPTION


Adds all six events emitted by the Oracle Adapter for the off-chain Event Indexer: Initialized, PriceUpdated, AdminChanged, StalenessThresholdUpdated, FeederAdded, FeederRemoved. Each event uses soroban_sdk::contractevent with typed topic tuples via .publish(&env). Relocates AdminChanged from lib.rs to events.rs and introduces supporting admin-gated setters set_staleness_threshold, add_feeder, and remove_feeder plus OracleError::AlreadyFeeder and OracleError::NotFeeder. Storage grows by DataKey::Feeder(Address) in instance storage to track authorized feeders. Tests verify each new event topic and the corresponding failure paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin controls to update the staleness threshold.
  * Added feeder management so admins can add or remove feeders.
  * Added new contract events for admin changes, threshold updates, and feeder lifecycle changes.

* **Bug Fixes**
  * Improved validation for threshold updates and feeder operations, including clearer failures when actions are invalid or repeated.

* **Tests**
  * Expanded coverage for event emission and success/failure cases around threshold and feeder updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->