### PR TITLE
test(oracle-adapter): cover is_price_fresh and get_price_or_fail staleness logic

### DIFF
--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -9,6 +9,8 @@ pub enum OracleError {
     AlreadyAdmin = 2,
     OraclePaused = 3,
     AlreadyPaused = 4,
+    PriceNotFound = 5,
+    StalePrice = 6,
 }
 
 #[contractevent]
@@ -61,6 +63,29 @@ impl OracleContract {
             Some(delta) => delta <= threshold,
             None => false,
         }
+    }
+
+    pub fn get_price_or_fail(env: Env, asset: Address) -> PriceData {
+        let data = match storage::get_price(&env, &asset) {
+            Some(data) => data,
+            None => soroban_sdk::panic_with_error!(&env, OracleError::PriceNotFound),
+        };
+
+        let threshold = match storage::get_staleness_threshold(&env) {
+            Some(threshold) => threshold,
+            None => soroban_sdk::panic_with_error!(&env, OracleError::NotInitialized),
+        };
+
+        let ledger_time = env.ledger().timestamp();
+        let is_stale = match ledger_time.checked_sub(data.timestamp) {
+            Some(delta) => delta > threshold,
+            None => false,
+        };
+        if is_stale {
+            soroban_sdk::panic_with_error!(&env, OracleError::StalePrice);
+        }
+
+        data
     }
 
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {

--- a/contracts/oracle-adapter/src/tests/mod.rs
+++ b/contracts/oracle-adapter/src/tests/mod.rs
@@ -429,3 +429,4 @@ fn test_get_admin_requires_no_auth() {
 
 mod test_pause;
 pub mod test_price;
+mod test_staleness;

--- a/contracts/oracle-adapter/src/tests/test_staleness.rs
+++ b/contracts/oracle-adapter/src/tests/test_staleness.rs
@@ -1,0 +1,128 @@
+#![cfg(test)]
+
+use crate::{OracleContract, OracleContractClient, OracleError};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env};
+
+const STALENESS_THRESHOLD: u64 = 300;
+
+fn setup() -> (Env, OracleContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(OracleContract, ());
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &STALENESS_THRESHOLD);
+
+    (env, client, admin)
+}
+
+#[test]
+fn test_is_price_fresh_returns_true_for_recent_price() {
+    let (env, client, _admin) = setup();
+    let asset = Address::generate(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&asset, &100, &900);
+
+    assert!(client.is_price_fresh(&asset));
+}
+
+#[test]
+fn test_is_price_fresh_returns_false_for_stale_price() {
+    let (env, client, _admin) = setup();
+    let asset = Address::generate(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&asset, &100, &500);
+
+    assert!(!client.is_price_fresh(&asset));
+}
+
+#[test]
+fn test_is_price_fresh_returns_false_for_unknown_asset() {
+    let (env, client, _admin) = setup();
+    let unknown_asset = Address::generate(&env);
+
+    assert!(!client.is_price_fresh(&unknown_asset));
+}
+
+#[test]
+fn test_get_price_or_fail_success() {
+    let (env, client, _admin) = setup();
+    let asset = Address::generate(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&asset, &12_345, &900);
+
+    let data = client.get_price_or_fail(&asset);
+    assert_eq!(data.price, 12_345);
+    assert_eq!(data.timestamp, 900);
+}
+
+#[test]
+fn test_get_price_or_fail_panics_on_missing_price() {
+    let (env, client, _admin) = setup();
+    let unknown_asset = Address::generate(&env);
+
+    let result = client.try_get_price_or_fail(&unknown_asset);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::PriceNotFound as u32)
+    );
+}
+
+#[test]
+fn test_get_price_or_fail_panics_on_stale_price() {
+    let (env, client, _admin) = setup();
+    let asset = Address::generate(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&asset, &100, &500);
+
+    let result = client.try_get_price_or_fail(&asset);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::StalePrice as u32)
+    );
+}
+
+#[test]
+fn test_staleness_boundary_exact_threshold() {
+    let (env, client, _admin) = setup();
+    let asset = Address::generate(&env);
+
+    client.set_price(&asset, &100, &100);
+    env.ledger().set_timestamp(400);
+
+    assert!(client.is_price_fresh(&asset));
+
+    let data = client.get_price_or_fail(&asset);
+    assert_eq!(data.price, 100);
+    assert_eq!(data.timestamp, 100);
+}
+
+#[test]
+fn test_staleness_boundary_one_second_over() {
+    let (env, client, _admin) = setup();
+    let asset = Address::generate(&env);
+
+    client.set_price(&asset, &100, &100);
+    env.ledger().set_timestamp(401);
+
+    assert!(!client.is_price_fresh(&asset));
+
+    let result = client.try_get_price_or_fail(&asset);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::StalePrice as u32)
+    );
+}


### PR DESCRIPTION


Add get_price_or_fail with PriceNotFound and StalePrice errors (dependency of the test issue), plus test_staleness.rs with all 8 required cases. Closes #523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added oracle price retrieval that returns stored price data when it exists and is fresh.
  * Added explicit errors for missing prices and stale price data.
* **Bug Fixes**
  * Improved price freshness evaluation, including correct behavior at the exact staleness threshold.
* **Tests**
  * Added automated coverage for fresh, stale, missing, and boundary-case scenarios for price freshness and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->