### PR TITLE
feat: clean-up get_price_or_fail with addtl test

### DIFF
--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -21,7 +21,7 @@ pub trait LendingPool {
 const PRICE_PRECISION: i128 = 10_000_000;
 
 /// Maximum age (in seconds) an oracle price may have before it is considered stale.
-const ORACLE_STALE_THRESHOLD: u64 = 300;
+
 
 #[contract]
 pub struct VaultContract;

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -22,7 +22,6 @@ const PRICE_PRECISION: i128 = 10_000_000;
 
 /// Maximum age (in seconds) an oracle price may have before it is considered stale.
 
-
 #[contract]
 pub struct VaultContract;
 

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -7,6 +7,7 @@ use types::Position;
 #[soroban_sdk::contractclient(name = "OracleClient")]
 pub trait Oracle {
     fn get_price(env: Env, asset: Address) -> Option<types::PriceData>;
+    fn get_price_or_fail(env: Env, asset: Address) -> types::PriceData;
 }
 
 #[soroban_sdk::contractclient(name = "LendingPoolClient")]
@@ -389,19 +390,9 @@ impl VaultContract {
         let oracle_client = OracleClient::new(&env, &oracle_address);
 
         let mut total_value: i128 = 0;
-        let current_time = env.ledger().timestamp();
 
         for item in position.collateral.iter() {
-            let price_data = match oracle_client.get_price(&item.asset) {
-                Some(pd) => pd,
-                None => soroban_sdk::panic_with_error!(&env, VaultError::AssetNotFound),
-            };
-
-            if current_time > price_data.timestamp
-                && current_time - price_data.timestamp > ORACLE_STALE_THRESHOLD
-            {
-                soroban_sdk::panic_with_error!(&env, VaultError::StalePrice);
-            }
+            let price_data = oracle_client.get_price_or_fail(&item.asset);
 
             // Compute USD value: amount * price / PRICE_PRECISION.
             // checked_mul guards against overflow before the safe integer division.

--- a/contracts/collateral-vault/src/tests/test_read_functions.rs
+++ b/contracts/collateral-vault/src/tests/test_read_functions.rs
@@ -4,9 +4,11 @@ use super::super::*;
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
 
+const ORACLE_STALE_THRESHOLD: u64 = 300;
+
 // Mock Oracle Contract to inject prices for testing get_collateral_value
 #[contract]
-pub struct MockOracleContract;
+pub struct MockOracleContract;  
 
 #[contractimpl]
 impl MockOracleContract {

--- a/contracts/collateral-vault/src/tests/test_read_functions.rs
+++ b/contracts/collateral-vault/src/tests/test_read_functions.rs
@@ -8,7 +8,7 @@ const ORACLE_STALE_THRESHOLD: u64 = 300;
 
 // Mock Oracle Contract to inject prices for testing get_collateral_value
 #[contract]
-pub struct MockOracleContract;  
+pub struct MockOracleContract;
 
 #[contractimpl]
 impl MockOracleContract {
@@ -22,9 +22,11 @@ impl MockOracleContract {
             None => panic!("price not found"),
         };
         let current_time = env.ledger().timestamp();
-        if current_time > price_data.timestamp
-            && current_time - price_data.timestamp > ORACLE_STALE_THRESHOLD
-        {
+        let age = match current_time.checked_sub(price_data.timestamp) {
+            Some(delta) => delta,
+            None => panic!("stale price"),
+        };
+        if age > ORACLE_STALE_THRESHOLD {
             panic!("stale price");
         }
         price_data

--- a/contracts/collateral-vault/src/tests/test_read_functions.rs
+++ b/contracts/collateral-vault/src/tests/test_read_functions.rs
@@ -14,6 +14,20 @@ impl MockOracleContract {
         env.storage().persistent().get(&asset)
     }
 
+    pub fn get_price_or_fail(env: Env, asset: Address) -> types::PriceData {
+        let price_data: types::PriceData = match env.storage().persistent().get(&asset) {
+            Some(pd) => pd,
+            None => panic!("price not found"),
+        };
+        let current_time = env.ledger().timestamp();
+        if current_time > price_data.timestamp
+            && current_time - price_data.timestamp > ORACLE_STALE_THRESHOLD
+        {
+            panic!("stale price");
+        }
+        price_data
+    }
+
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
         let price_data = types::PriceData { price, timestamp };
         env.storage().persistent().set(&asset, &price_data);

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -4,6 +4,8 @@ use super::super::*;
 use soroban_sdk::testutils::{Address as _, Events, Ledger};
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
 
+const ORACLE_STALE_THRESHOLD: u64 = 300;
+
 #[contract]
 pub struct MockLendingPool;
 

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -35,9 +35,11 @@ impl MockOracle {
             None => panic!("price not found"),
         };
         let current_time = env.ledger().timestamp();
-        if current_time > price_data.timestamp
-            && current_time - price_data.timestamp > ORACLE_STALE_THRESHOLD
-        {
+        let age = match current_time.checked_sub(price_data.timestamp) {
+            Some(delta) => delta,
+            None => panic!("stale price"),
+        };
+        if age > ORACLE_STALE_THRESHOLD {
             panic!("stale price");
         }
         price_data

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -27,6 +27,20 @@ impl MockOracle {
         env.storage().persistent().get(&asset)
     }
 
+    pub fn get_price_or_fail(env: Env, asset: Address) -> types::PriceData {
+        let price_data: types::PriceData = match env.storage().persistent().get(&asset) {
+            Some(pd) => pd,
+            None => panic!("price not found"),
+        };
+        let current_time = env.ledger().timestamp();
+        if current_time > price_data.timestamp
+            && current_time - price_data.timestamp > ORACLE_STALE_THRESHOLD
+        {
+            panic!("stale price");
+        }
+        price_data
+    }
+
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
         let price_data = types::PriceData { price, timestamp };
         env.storage().persistent().set(&asset, &price_data);

--- a/contracts/oracle-adapter/src/errors.rs
+++ b/contracts/oracle-adapter/src/errors.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum OracleError {
+    NotInitialized = 1,
+    AlreadyAdmin = 2,
+    OraclePaused = 3,
+    AlreadyPaused = 4,
+    FeederNotFound = 5,
+    NotPaused = 6,
+    AlreadyAuthorized = 7,
+    Unauthorized = 8,
+    UnknownFeed = 9,
+    InvalidPayload = 10,
+    FeedNotWritten = 11,
+    PriceNotFound = 12,
+    StalePrice = 13,
+}

--- a/contracts/oracle-adapter/src/errors.rs
+++ b/contracts/oracle-adapter/src/errors.rs
@@ -17,4 +17,5 @@ pub enum OracleError {
     FeedNotWritten = 11,
     PriceNotFound = 12,
     StalePrice = 13,
+    ThresholdZero = 14,
 }

--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, Address, Bytes, Env, Symbol, Vec,
+    contract, contractevent, contractimpl, Address, Bytes, Env, Symbol, Vec,
 };
 
 mod errors;

--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-use soroban_sdk::{
-    contract, contractevent, contractimpl, Address, Bytes, Env, Symbol, Vec,
-};
+use soroban_sdk::{contract, contractevent, contractimpl, Address, Bytes, Env, Symbol, Vec};
 
 mod errors;
 pub use errors::OracleError;

--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -3,22 +3,8 @@ use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, Address, Bytes, Env, Symbol, Vec,
 };
 
-#[contracterror]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
-pub enum OracleError {
-    NotInitialized = 1,
-    AlreadyAdmin = 2,
-    OraclePaused = 3,
-    AlreadyPaused = 4,
-    FeederNotFound = 5,
-    NotPaused = 6,
-    AlreadyAuthorized = 7,
-    Unauthorized = 8,
-    UnknownFeed = 9,
-    InvalidPayload = 10,
-    FeedNotWritten = 11,
-}
+mod errors;
+pub use errors::OracleError;
 
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
@@ -79,23 +65,14 @@ impl OracleContract {
     }
 
     pub fn get_price_or_fail(env: Env, asset: Address) -> PriceData {
-        let price_data = match storage::get_price(&env, &asset) {
-            Some(data) => data,
+        let price = match Self::get_price(env.clone(), asset.clone()) {
+            Some(price) => price,
             None => soroban_sdk::panic_with_error!(&env, OracleError::PriceNotFound),
         };
-        let threshold = match storage::get_staleness_threshold(&env) {
-            Some(t) => t,
-            None => soroban_sdk::panic_with_error!(&env, OracleError::NotInitialized),
-        };
-        let ledger_time = env.ledger().timestamp();
-        let is_fresh = match ledger_time.checked_sub(price_data.timestamp) {
-            Some(delta) => delta <= threshold,
-            None => false,
-        };
-        if !is_fresh {
+        if !Self::is_price_fresh(env.clone(), asset) {
             soroban_sdk::panic_with_error!(&env, OracleError::StalePrice);
         }
-        price_data
+        price
     }
 
     pub fn set_price(env: Env, caller: Address, asset: Address, price: i128, timestamp: u64) {

--- a/contracts/oracle-adapter/src/tests/test_staleness.rs
+++ b/contracts/oracle-adapter/src/tests/test_staleness.rs
@@ -13,7 +13,7 @@ fn test_set_staleness_threshold_success() {
     client.set_staleness_threshold(&500_u64);
 
     let result = client.get_staleness_threshold();
-    assert_eq!(result, Some(500));
+    assert_eq!(result, 500);
 }
 
 #[test]


### PR DESCRIPTION
- Closes #513 

## Overview
Implements `get_price_or_fail`, a strict variant of `get_price` that panics if the price is missing or stale. Replaces the manual price staleness checks in the Collateral Vault's `get_collateral_value` function with this new adapter method.

## Key Changes
- **Oracle Adapter**:
  - Created [errors.rs](file:///c:/Users/LENOVO/Documents/drips-waves/Alien-Protocol/contracts/oracle-adapter/src/errors.rs) and moved the `OracleError` enum definition there, adding `PriceNotFound = 12` and `StalePrice = 13` variants.
  - Implemented `get_price_or_fail` in [lib.rs](file:///c:/Users/LENOVO/Documents/drips-waves/Alien-Protocol/contracts/oracle-adapter/src/lib.rs) by delegating to `get_price` and `is_price_fresh`.
- **Collateral Vault**:
  - Updated the `Oracle` client trait to include `get_price_or_fail`.
  - Updated `get_collateral_value` to fetch asset prices via `get_price_or_fail`, delegating the staleness check entirely to the Oracle.
  - Updated mock oracle contracts in tests to implement `get_price_or_fail`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “fail on missing price” oracle pricing method for collateral value calculations and withdrawals.
  * Introduced standardized adapter error types to clearly represent price-not-found and stale-price conditions.

* **Bug Fixes**
  * Improved handling of stale pricing by directly rejecting outdated oracle data during price reads.
  * Updated staleness behavior to consistently treat missing thresholds as stale.

* **Tests**
  * Revised oracle test mocks and assertions to match the new pricing and staleness flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->