### PR TITLE
Feat/oracle events

### DIFF
--- a/contracts/oracle-adapter/src/events.rs
+++ b/contracts/oracle-adapter/src/events.rs
@@ -17,6 +17,12 @@ pub struct PriceUpdated {
 
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
+pub struct AdminChanged {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Paused {
     pub by: Address,
 }
@@ -27,6 +33,11 @@ pub struct Unpaused {
     pub by: Address,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct FeederAdded {
+    pub feeder: Address,
+}
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct FeederRemoved {

--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -4,7 +4,6 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, Symbol, Vec};
 mod errors;
 pub use errors::OracleError;
 
-
 mod events;
 pub mod oracle;
 mod storage;

--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -1,20 +1,9 @@
 #![no_std]
-use soroban_sdk::{contract, contractevent, contractimpl, Address, Bytes, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, Symbol, Vec};
 
 mod errors;
 pub use errors::OracleError;
 
-#[contractevent]
-#[derive(Clone, Debug, PartialEq)]
-pub struct AdminChanged {
-    pub old_admin: Address,
-    pub new_admin: Address,
-}
-#[contractevent]
-#[derive(Clone, Debug, PartialEq)]
-pub struct FeederAdded {
-    pub feeder: Address,
-}
 
 mod events;
 pub mod oracle;
@@ -153,7 +142,7 @@ impl OracleContract {
 
         storage::set_admin(&env, &new_admin);
 
-        AdminChanged {
+        events::AdminChanged {
             old_admin: current_admin,
             new_admin,
         }
@@ -203,7 +192,7 @@ impl OracleContract {
 
         storage::set_authorized_feeder(&env, &feeder);
 
-        FeederAdded { feeder }.publish(&env);
+        events::FeederAdded { feeder }.publish(&env);
     }
 
     pub fn remove_authorized_feeder(env: Env, feeder: Address) {

--- a/contracts/oracle-adapter/src/tests/mod.rs
+++ b/contracts/oracle-adapter/src/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
-use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, Env};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{Address, Env, Symbol, TryFromVal};
 
 pub(crate) fn setup_env() -> (Env, OracleContractClient<'static>, Address) {
     let env = Env::default();
@@ -31,6 +31,21 @@ fn test_initialize_success() {
     let price_data = client.get_price(&asset).unwrap();
     assert_eq!(price_data.price, 100);
     assert_eq!(price_data.timestamp, 1000);
+}
+
+#[test]
+fn test_initialize_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register(OracleContract, ());
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &300);
+
+    let last_event = env.events().all().last().unwrap();
+    assert_eq!(last_event.0, client.address);
+    let event_symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(event_symbol, Symbol::new(&env, "initialized"));
 }
 
 #[test]

--- a/contracts/oracle-adapter/test_snapshots/tests/test_initialize_emits_event.1.json
+++ b/contracts/oracle-adapter/test_snapshots/tests/test_initialize_emits_event.1.json
@@ -1,0 +1,152 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "StalenessThreshold"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": "300"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "initialized"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "admin"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "staleness_threshold"
+                  },
+                  "val": {
+                    "u64": "300"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
## What
Consolidates the Oracle Adapter's contract events into `contracts/oracle-adapter/src/events.rs`,
and adds the missing dedicated test for the `Initialized` event.

## Why
Four of six required events (`Initialized`, `PriceUpdated`, `StalenessThresholdUpdated`,
`FeederRemoved`) were already correctly defined in `events.rs` and wired up. `AdminChanged` and
`FeederAdded` were functionally complete and emitting correctly, but defined inline in `lib.rs`,
inconsistent with the one-file convention `collateral-vault/src/events.rs` establishes elsewhere
in the repo. Separately, `Initialized` had no dedicated `test_X_emits_event` test, unlike every
other event — `test_initialize_success` only checked follow-on price data, never asserted anything
about the `Initialized` event itself.

## What changed
- Moved `AdminChanged` and `FeederAdded` into `events.rs`.
- Removed the duplicate definitions and the now-unused `contractevent` import from `lib.rs`.
- Updated call sites to `events::AdminChanged` / `events::FeederAdded`, matching the other four.
- Added `test_initialize_emits_event`, matching the existing pattern used for every other event.
- Added the resulting `test_snapshots/tests/test_initialize_emits_event.1.json`.

## Note on the "typed topic tuple" implementation guideline
The issue describes using `env.events().publish(...)` with a manual typed topic tuple. This repo has
already standardized on `#[contractevent]` (soroban-sdk's derive macro, confirmed via its docs to
derive the topic from the struct name only — not from module path) for every existing event,
including in `collateral-vault`. Kept that pattern for `AdminChanged`/`FeederAdded` rather than
introducing the manual style, to avoid two competing event-emission idioms in one contract.

## Out of scope
`oracle/push.rs` defines a 7th event, `FeedPriceUpdated`, inline — same inconsistency pattern, but
outside the 6 events this issue lists and belongs to the separate RedStone feature. Left untouched
to keep this PR minimal.

## Testing
`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace` — all passing locally (55 tests). New snapshot file generated by the
SDK during the test run and committed alongside the code.

Closes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contract events for administrator changes and feeder additions.
  * Initialization now emits an event containing the administrator and staleness threshold.
* **Tests**
  * Added coverage verifying that initialization emits the expected event (including topic and payload).
  * Added snapshot data for the initialization event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->