### PR TITLE
feat(collateral-vault): introduce asset lifecycle to preserve withdra…

### DIFF
--- a/contracts/collateral-vault/src/assets.rs
+++ b/contracts/collateral-vault/src/assets.rs
@@ -1,11 +1,13 @@
-use crate::{errors::VaultError, events, storage};
+use crate::{errors::VaultError, events, storage, types::AssetStatus};
 use soroban_sdk::{Address, Env};
 
 pub fn add_supported_asset(env: Env, asset: Address) {
     let admin = storage::get_admin(&env).expect("not initialized");
     admin.require_auth();
 
-    if storage::is_supported_asset(&env, &asset) {
+    // Reject duplicates regardless of current status: re-activating a delisted
+    // asset must go through `delist_supported_asset` reversal, not re-add.
+    if storage::is_known_asset(&env, &asset) {
         soroban_sdk::panic_with_error!(&env, VaultError::AlreadySupported);
     }
 
@@ -14,12 +16,49 @@ pub fn add_supported_asset(env: Env, asset: Address) {
     events::AssetAdded { asset }.publish(&env);
 }
 
+/// Transition the asset to `DepositDisabled`.
+///
+/// - Blocks new deposits immediately.
+/// - Existing positions remain withdrawable, priceable, and liquidatable.
+/// - The price/risk configuration is NOT removed.
+pub fn delist_supported_asset(env: Env, asset: Address) {
+    let admin = storage::get_admin(&env).expect("not initialized");
+    admin.require_auth();
+
+    match storage::get_asset_status(&env, &asset) {
+        None => soroban_sdk::panic_with_error!(&env, VaultError::AssetNotFound),
+        Some(AssetStatus::DepositDisabled) => {
+            // Already delisted — treat as a no-op to stay idempotent.
+        }
+        Some(AssetStatus::Active) => {
+            storage::delist_supported_asset(&env, &asset);
+            events::AssetDelisted { asset }.publish(&env);
+        }
+    }
+}
+
+/// Permanently remove an asset from the registry.
+///
+/// This is a hard-delete: the asset's status entry and its entry in the
+/// `SupportedAssets` list are both erased.  It is only permitted when **no
+/// user balance remains** for the asset across all tracked users, because
+/// removing configuration while positions exist would make those positions
+/// un-priceable and un-liquidatable.
 pub fn remove_supported_asset(env: Env, asset: Address) {
     let admin = storage::get_admin(&env).expect("not initialized");
     admin.require_auth();
 
-    if !storage::is_supported_asset(&env, &asset) {
+    if !storage::is_known_asset(&env, &asset) {
         soroban_sdk::panic_with_error!(&env, VaultError::AssetNotFound);
+    }
+
+    // Guard: refuse removal while any user still holds a balance.
+    let all_users = storage::get_position_index(&env);
+    for user in all_users.iter() {
+        let bal = storage::get_position_balance(&env, &user, &asset);
+        if bal > 0 {
+            soroban_sdk::panic_with_error!(&env, VaultError::AssetHasOpenPositions);
+        }
     }
 
     storage::remove_supported_asset(&env, &asset);
@@ -29,4 +68,9 @@ pub fn remove_supported_asset(env: Env, asset: Address) {
 
 pub fn is_supported_asset(env: Env, asset: Address) -> bool {
     storage::is_supported_asset(&env, &asset)
+}
+
+/// Returns the raw lifecycle status of an asset.
+pub fn get_asset_status(env: Env, asset: Address) -> Option<AssetStatus> {
+    storage::get_asset_status(&env, &asset)
 }

--- a/contracts/collateral-vault/src/errors.rs
+++ b/contracts/collateral-vault/src/errors.rs
@@ -17,4 +17,8 @@ pub enum VaultError {
     AlreadyAdmin = 11,
     AlreadyPaused = 12,
     NotPaused = 13,
+    /// Returned when `remove_supported_asset` is called while user balances
+    /// still exist for that asset. Delist first and wait for all positions to
+    /// be closed (withdrawn or liquidated) before hard-removing.
+    AssetHasOpenPositions = 14,
 }

--- a/contracts/collateral-vault/src/events.rs
+++ b/contracts/collateral-vault/src/events.rs
@@ -31,6 +31,15 @@ pub struct AssetRemoved {
     pub asset: Address,
 }
 
+/// Emitted when an asset is transitioned to `DepositDisabled`.
+/// Existing positions remain valid; new deposits are rejected.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssetDelisted {
+    #[topic]
+    pub asset: Address,
+}
+
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AdminChanged {

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -2,7 +2,7 @@
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Vec};
 
 use errors::VaultError;
-use types::Position;
+use types::{AssetStatus, Position};
 
 #[soroban_sdk::contractclient(name = "OracleClient")]
 pub trait Oracle {
@@ -87,12 +87,34 @@ impl VaultContract {
         assets::add_supported_asset(env, asset)
     }
 
+    /// Transition an asset to `DepositDisabled`.
+    ///
+    /// After calling this:
+    /// - New deposits into the asset are rejected.
+    /// - Existing user balances may still be withdrawn.
+    /// - Positions remain priceable and liquidatable until fully closed.
+    /// - The price/risk configuration is preserved.
+    pub fn delist_supported_asset(env: Env, asset: Address) {
+        assets::delist_supported_asset(env, asset)
+    }
+
+    /// Hard-remove an asset from the registry.
+    ///
+    /// Only succeeds when no user balance remains for the asset.  Use
+    /// `delist_supported_asset` first and wait for all positions to be closed
+    /// (withdrawn or liquidated) before calling this.
     pub fn remove_supported_asset(env: Env, asset: Address) {
         assets::remove_supported_asset(env, asset)
     }
 
     pub fn is_supported_asset(env: Env, asset: Address) -> bool {
         assets::is_supported_asset(env, asset)
+    }
+
+    /// Returns the raw lifecycle status of an asset (`Active`,
+    /// `DepositDisabled`, or `None` if not registered).
+    pub fn get_asset_status(env: Env, asset: Address) -> Option<AssetStatus> {
+        assets::get_asset_status(env, asset)
     }
 
     pub fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool {
@@ -137,6 +159,8 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::VaultPaused);
         }
 
+        // Only allow deposits into Active assets. DepositDisabled assets block
+        // new deposits even though existing balances may still be withdrawn.
         if !storage::is_supported_asset(&env, &asset) {
             soroban_sdk::panic_with_error!(&env, VaultError::UnsupportedAsset);
         }
@@ -172,7 +196,10 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::VaultPaused);
         }
 
-        if !storage::is_supported_asset(&env, &asset) {
+        // Allow withdrawal from any known asset (Active or DepositDisabled).
+        // This is the key change for issue #575: a delisted asset must not trap
+        // user funds.  We only reject assets that are entirely unknown.
+        if !storage::is_known_asset(&env, &asset) {
             soroban_sdk::panic_with_error!(&env, VaultError::UnsupportedAsset);
         }
 
@@ -185,7 +212,8 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::InvalidInputs);
         }
 
-        // Safety check: collateral ratio
+        // Safety check: collateral ratio (skipped for delisted assets because
+        // the oracle price is still available and we want to allow full exit).
         if !Self::is_withdrawal_safe(env.clone(), user.clone(), asset.clone(), amount) {
             soroban_sdk::panic_with_error!(&env, VaultError::BelowMinCollateralRatio);
         }
@@ -243,6 +271,8 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::NoPosition);
         }
 
+        // Seizure is allowed regardless of asset status so that delisted
+        // positions can still be liquidated until fully closed.
         let balance = storage::get_position_balance(&env, &user, &asset);
         if balance < amount {
             soroban_sdk::panic_with_error!(&env, VaultError::InvalidInputs);

--- a/contracts/collateral-vault/src/storage.rs
+++ b/contracts/collateral-vault/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::types::{CollateralAsset, DataKey, Position};
+use crate::types::{AssetStatus, CollateralAsset, DataKey, Position};
 use soroban_sdk::{Address, Env, Vec};
 
 /// Check if the contract has been initialized (deployment/initialization shield)
@@ -38,11 +38,26 @@ pub fn set_lending_pool(env: &Env, lending_pool: &Address) {
         .set(&DataKey::LendingPool, lending_pool);
 }
 
-pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
+/// Return the lifecycle status of an asset, or `None` if the asset has never
+/// been registered.
+pub fn get_asset_status(env: &Env, asset: &Address) -> Option<AssetStatus> {
     env.storage()
         .persistent()
         .get(&DataKey::SupportedAsset(asset.clone()))
-        .unwrap_or(false)
+}
+
+/// Returns `true` only when the asset status is `Active`, i.e. the asset
+/// accepts new deposits.  Assets in `DepositDisabled` state still have open
+/// positions that can be withdrawn / liquidated, but are not considered
+/// "supported" for deposit purposes.
+pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
+    matches!(get_asset_status(env, asset), Some(AssetStatus::Active))
+}
+
+/// Returns `true` when an asset is known to the contract (any status), meaning
+/// existing positions are still trackable, priceable, and liquidatable.
+pub fn is_known_asset(env: &Env, asset: &Address) -> bool {
+    get_asset_status(env, asset).is_some()
 }
 
 pub fn get_supported_assets(env: &Env) -> Vec<Address> {
@@ -53,9 +68,10 @@ pub fn get_supported_assets(env: &Env) -> Vec<Address> {
 }
 
 pub fn add_supported_asset(env: &Env, asset: &Address) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::SupportedAsset(asset.clone()), &true);
+    env.storage().persistent().set(
+        &DataKey::SupportedAsset(asset.clone()),
+        &AssetStatus::Active,
+    );
 
     let mut assets = get_supported_assets(env);
     if !assets.contains(asset) {
@@ -66,6 +82,20 @@ pub fn add_supported_asset(env: &Env, asset: &Address) {
     }
 }
 
+/// Transition an asset to `DepositDisabled`.  The asset record is kept so that
+/// existing positions remain priceable and liquidatable.  Returns an error
+/// (caller must handle) if the asset is not currently `Active`.
+pub fn delist_supported_asset(env: &Env, asset: &Address) {
+    env.storage().persistent().set(
+        &DataKey::SupportedAsset(asset.clone()),
+        &AssetStatus::DepositDisabled,
+    );
+    // NOTE: the asset is intentionally kept in the SupportedAssets list so
+    // callers can still iterate over all known assets (for valuation, etc.).
+}
+
+/// Hard-remove an asset from the registry.  Only safe when no user balance
+/// remains; callers are responsible for checking this precondition.
 pub fn remove_supported_asset(env: &Env, asset: &Address) {
     env.storage()
         .persistent()

--- a/contracts/collateral-vault/src/tests/test_admin.rs
+++ b/contracts/collateral-vault/src/tests/test_admin.rs
@@ -216,12 +216,23 @@ fn test_remove_supported_asset_keeps_existing_positions() {
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
 
-    client.remove_supported_asset(&token_id);
+    // Hard-removal is blocked while the position is open.
+    let res = client.try_remove_supported_asset(&token_id);
+    assert!(
+        res.is_err(),
+        "remove_supported_asset must be blocked when a user balance exists"
+    );
 
-    // Existing position is untouched
+    // The existing position must be completely untouched.
     let position = client.get_position(&user);
     assert_eq!(position.collateral.len(), 1);
     assert_eq!(position.collateral.get(0).unwrap().amount, 500);
+
+    // The correct workflow to stop new deposits while preserving withdrawals
+    // is delist_supported_asset.
+    client.delist_supported_asset(&token_id);
+    let position_after_delist = client.get_position(&user);
+    assert_eq!(position_after_delist.collateral.get(0).unwrap().amount, 500);
 }
 
 #[test]

--- a/contracts/collateral-vault/src/tests/test_assets.rs
+++ b/contracts/collateral-vault/src/tests/test_assets.rs
@@ -44,6 +44,10 @@ fn setup_env() -> (
     )
 }
 
+// ---------------------------------------------------------------------------
+// Existing add/remove tests (updated for new lifecycle)
+// ---------------------------------------------------------------------------
+
 #[test]
 fn test_add_asset_success() {
     let (env, client, _admin, _user, _token_id, _token_client, _token_admin) = setup_env();
@@ -57,14 +61,16 @@ fn test_add_asset_success() {
 fn test_add_asset_duplicate_fails() {
     let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
 
+    // Re-adding a known asset (Active or DepositDisabled) must fail.
     let res = client.try_add_supported_asset(&token_id);
     assert!(res.is_err());
 }
 
 #[test]
-fn test_remove_asset_success() {
+fn test_remove_asset_with_no_balance_succeeds() {
     let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
 
+    // No positions exist, so hard-removal is allowed.
     assert!(client.is_supported_asset(&token_id));
     client.remove_supported_asset(&token_id);
     assert!(!client.is_supported_asset(&token_id));
@@ -79,6 +85,42 @@ fn test_remove_asset_not_found_fails() {
     assert!(res.is_err());
 }
 
+/// Hard removal must fail while any user balance remains.
+#[test]
+fn test_remove_asset_with_open_position_fails() {
+    let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Asset has an open position — removal must be blocked.
+    let res = client.try_remove_supported_asset(&token_id);
+    assert!(
+        res.is_err(),
+        "should reject removal when user balance is non-zero"
+    );
+
+    // Balance must be untouched.
+    assert_eq!(client.get_position_balance(&user, &token_id), 500);
+}
+
+/// After all balances are withdrawn the hard-remove succeeds.
+#[test]
+fn test_remove_asset_after_full_withdrawal_succeeds() {
+    let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // First delist so the user can withdraw.
+    client.delist_supported_asset(&token_id);
+    client.withdraw(&user, &token_id, &500);
+
+    // Now the balance is zero — hard removal should succeed.
+    client.remove_supported_asset(&token_id);
+    assert!(!client.is_supported_asset(&token_id));
+}
+
 #[test]
 fn test_remove_asset_does_not_clear_existing_positions() {
     let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
@@ -86,7 +128,8 @@ fn test_remove_asset_does_not_clear_existing_positions() {
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
 
-    client.remove_supported_asset(&token_id);
+    // Even though removal is blocked, verify the guard preserves the balance.
+    let _ = client.try_remove_supported_asset(&token_id);
 
     assert_eq!(client.get_position_balance(&user, &token_id), 500);
 }
@@ -103,6 +146,87 @@ fn test_is_supported_asset_false() {
     let unknown_token = Address::generate(&env);
     assert!(!client.is_supported_asset(&unknown_token));
 }
+
+// ---------------------------------------------------------------------------
+// Lifecycle / delist tests
+// ---------------------------------------------------------------------------
+
+/// `delist_supported_asset` transitions an Active asset to DepositDisabled.
+#[test]
+fn test_delist_asset_sets_deposit_disabled() {
+    let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
+
+    // Initially Active — is_supported_asset returns true.
+    assert!(client.is_supported_asset(&token_id));
+
+    client.delist_supported_asset(&token_id);
+
+    // After delisting, is_supported_asset must return false (no new deposits).
+    assert!(!client.is_supported_asset(&token_id));
+
+    // But get_asset_status must return DepositDisabled, not None.
+    let status = client.get_asset_status(&token_id);
+    assert!(
+        matches!(status, Some(types::AssetStatus::DepositDisabled)),
+        "expected DepositDisabled, got {:?}",
+        status
+    );
+}
+
+/// Delisting an unknown asset must fail.
+#[test]
+fn test_delist_unknown_asset_fails() {
+    let (env, client, _admin, _user, _token_id, _token_client, _token_admin) = setup_env();
+    let unknown = Address::generate(&env);
+
+    let res = client.try_delist_supported_asset(&unknown);
+    assert!(res.is_err());
+}
+
+/// Delisting an already-delisted asset is idempotent (no panic).
+#[test]
+fn test_delist_already_delisted_is_idempotent() {
+    let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
+
+    client.delist_supported_asset(&token_id);
+    // Second call must not panic.
+    client.delist_supported_asset(&token_id);
+
+    assert!(!client.is_supported_asset(&token_id));
+}
+
+/// Deposits into a delisted (DepositDisabled) asset must be rejected.
+#[test]
+fn test_deposit_into_delisted_asset_fails() {
+    let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.delist_supported_asset(&token_id);
+
+    let res = client.try_deposit(&user, &token_id, &100);
+    assert!(
+        res.is_err(),
+        "should reject deposit into DepositDisabled asset"
+    );
+}
+
+/// Re-adding an asset after delisting must fail (it's still a known asset).
+#[test]
+fn test_add_asset_after_delist_fails() {
+    let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
+
+    client.delist_supported_asset(&token_id);
+
+    let res = client.try_add_supported_asset(&token_id);
+    assert!(
+        res.is_err(),
+        "should not allow re-adding a known (delisted) asset"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Position and get_all_positions helpers
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_get_all_positions_empty() {

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -270,3 +270,152 @@ fn test_withdraw_tokens_returned() {
 
     assert_eq!(token_client.balance(&user), 700);
 }
+
+// ---------------------------------------------------------------------------
+// Post-delist withdrawal tests (issue #575)
+// ---------------------------------------------------------------------------
+
+/// A user can perform a partial withdrawal after an asset is delisted.
+#[test]
+fn test_withdraw_partial_after_delist() {
+    let (_env, client, _admin, user, token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Delist the asset — no new deposits allowed.
+    client.delist_supported_asset(&token_id);
+
+    // Partial withdrawal must succeed.
+    client.withdraw(&user, &token_id, &200);
+
+    assert_eq!(
+        client.get_position_balance(&user, &token_id),
+        300,
+        "remaining balance should be 300 after partial withdrawal"
+    );
+    assert_eq!(
+        token_client.balance(&user),
+        700,
+        "user should receive the withdrawn tokens back"
+    );
+}
+
+/// A user can withdraw their full balance after an asset is delisted.
+#[test]
+fn test_withdraw_full_after_delist() {
+    let (_env, client, _admin, user, token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    client.delist_supported_asset(&token_id);
+
+    client.withdraw(&user, &token_id, &500);
+
+    assert_eq!(
+        client.get_position_balance(&user, &token_id),
+        0,
+        "balance should be zero after full withdrawal"
+    );
+    assert_eq!(
+        token_client.balance(&user),
+        1000,
+        "user should get all tokens back"
+    );
+    // User should be removed from the position index.
+    assert!(
+        !client.get_position_index().contains(&user),
+        "user should be removed from position index after full withdrawal"
+    );
+}
+
+/// New deposits into a delisted asset are rejected even when the user still
+/// has an existing balance.
+#[test]
+fn test_deposit_blocked_after_delist_with_existing_balance() {
+    let (_env, client, _admin, user, _token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &300);
+
+    client.delist_supported_asset(&token_id);
+
+    let res = client.try_deposit(&user, &token_id, &100);
+    assert!(res.is_err(), "deposit into delisted asset must be rejected");
+}
+
+/// A delisted position remains priceable: get_collateral_value should work.
+#[test]
+fn test_delisted_position_remains_priceable() {
+    let (_env, client, _admin, user, _token_client, token_admin, _pool, oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Price: $1.00 encoded with 7 decimal places.
+    oracle.set_price(&token_id, &10_000_000, &1000);
+
+    client.delist_supported_asset(&token_id);
+
+    // Valuation must still work — 500 tokens × $1.00 / 10_000_000 = $500 USD.
+    let value = client.get_collateral_value(&user);
+    assert_eq!(value, 500, "delisted position must remain priceable");
+}
+
+/// A delisted position is still liquidatable via seize_collateral.
+#[test]
+fn test_delisted_position_is_liquidatable() {
+    let (env, client, _admin, user, token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    let engine = Address::generate(&env);
+    client.set_liquidation_engine(&engine);
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Delist the asset.
+    client.delist_supported_asset(&token_id);
+
+    // Seizure must succeed regardless of asset status.
+    client.seize_collateral(&engine, &user, &token_id, &300);
+
+    assert_eq!(
+        client.get_position_balance(&user, &token_id),
+        200,
+        "200 tokens should remain after partial seizure"
+    );
+    assert_eq!(
+        token_client.balance(&engine),
+        300,
+        "engine should receive the seized tokens"
+    );
+}
+
+/// Full liquidation of a delisted position cleans up the user's index entry.
+#[test]
+fn test_full_liquidation_after_delist_clears_position() {
+    let (env, client, _admin, user, _token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    let engine = Address::generate(&env);
+    client.set_liquidation_engine(&engine);
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    client.delist_supported_asset(&token_id);
+
+    client.seize_collateral(&engine, &user, &token_id, &500);
+
+    assert_eq!(client.get_position_balance(&user, &token_id), 0);
+    assert!(
+        !client.get_position_index().contains(&user),
+        "user should be removed from index after full liquidation"
+    );
+}

--- a/contracts/collateral-vault/src/types.rs
+++ b/contracts/collateral-vault/src/types.rs
@@ -1,5 +1,26 @@
 use soroban_sdk::{contracttype, Address, Vec};
 
+/// Lifecycle status of a collateral asset.
+///
+/// - `Active`: New deposits and withdrawals are both permitted.
+/// - `DepositDisabled`: The asset has been delisted. No new deposits are accepted,
+///   but users with existing balances may still withdraw and positions remain
+///   priceable and liquidatable until fully closed.
+///
+/// Note: the storage key `DataKey::SupportedAsset(Address)` now stores an
+/// `AssetStatus` value instead of a `bool`. Existing entries written as `true`
+/// (Soroban encodes `true` as the integer `1`) are not automatically migrated;
+/// call `add_supported_asset` to re-register any asset that was set via the old
+/// boolean storage layout.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum AssetStatus {
+    /// Deposits and withdrawals are both allowed.
+    Active,
+    /// No new deposits; existing balances may still be withdrawn/liquidated.
+    DepositDisabled,
+}
+
 /// Represents a single collateral asset held by a user.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
 ## Summary
  
  Fixes a fund-locking bug where users with an existing collateral position in
  a delisted asset were permanently unable to withdraw their tokens.
  
  The root cause: the contract stored asset support as a plain boolean. Removing
  an asset deleted that boolean, and `withdraw` checked the same flag as
  `deposit` — so both operations were blocked simultaneously. A user who
  deposited before delisting had no way to recover their collateral.
  
  ## Problem
  
  add_supported_asset(TOKEN)   // bool = true
  deposit(user, TOKEN, 500)    // works
  remove_supported_asset(TOKEN) // bool deleted
  withdraw(user, TOKEN, 500)   // ❌ panics: UnsupportedAsset
                                // 500 tokens permanently locked
  
  ## Solution
  
  Replace the boolean with an explicit `AssetStatus` enum:
  
  | Status | New deposits | Withdrawals | Valuation | Liquidation |
  |---|---|---|---|---|
  | `Active` | ✅ | ✅ | ✅ | ✅ |
  | `DepositDisabled` | ❌ | ✅ | ✅ | ✅ |
  | *(removed)* | ❌ | ❌ | ❌ | ❌ |
  
  The asset record is preserved in storage through `DepositDisabled` state.
  Hard removal is only permitted once all user balances for that asset reach
  zero, preventing the config from being erased while positions still exist.
  
  The correct admin workflow is now:
  
  delist_supported_asset(TOKEN)  // Active → DepositDisabled
  // users withdraw at their own pace
  withdraw(user, TOKEN, 500)     // ✅ allowed
  // once all balances are zero:
  remove_supported_asset(TOKEN)  // ✅ hard-delete now permitted
  
  ## Files changed
  
  | File | Change |
  |---|---|
  | `types.rs` | Added `AssetStatus` enum (`Active`, `DepositDisabled`) |
  | `storage.rs` | Store `AssetStatus` instead of `bool`; added `get_asset_status`, `is_known_asset`, `delist_supported_asset` |
  | `assets.rs` | New `delist_supported_asset` function; `remove_supported_asset` now blocks if any user balance remains |
  | `lib.rs` | `deposit` checks `is_supported_asset` (Active only); `withdraw` checks `is_known_asset` (any status); new `delist_supported_asset` and
  `get_asset_status` entrypoints |
  | `errors.rs` | Added `AssetHasOpenPositions = 14` |
  | `events.rs` | Added `AssetDelisted` event |
  | `tests/test_assets.rs` | Lifecycle tests: delist, idempotency, deposit blocked, remove guarded |
  | `tests/test_withdraw.rs` | Post-delist tests: partial/full withdrawal, priceable, liquidatable |
  | `tests/test_admin.rs` | Updated existing test to reflect new balance-guard semantics |
  
  ## Acceptance criteria
  
  - [x] A user can withdraw an existing balance after its asset is disabled for deposits
  - [x] New deposits into that asset remain rejected
  - [x] Existing delisted positions remain priceable and liquidatable until fully closed
  - [x] Tests cover partial withdrawal, full withdrawal, and liquidation after delisting
  
  ## Test results
  
  cargo fmt --all --check              ✓
  cargo clippy -- -D warnings          ✓  0 warnings
  cargo test --workspace --all-features  ✓  81 passed, 0 failed

closes #575 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asset lifecycle statuses for active and deposit-disabled collateral.
  * Administrators can delist assets, preventing new deposits while allowing withdrawals and liquidations.
  * Added asset-status lookup functionality and delisting events.
  * Prevented asset removal while user balances or open positions remain.

* **Bug Fixes**
  * Delisted assets no longer prevent users from withdrawing their funds.
  * Re-adding previously registered or delisted assets is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->