### PR TITLE
Feat/collateral vault per asset risk params 579

### DIFF
--- a/contracts/collateral-vault/src/assets.rs
+++ b/contracts/collateral-vault/src/assets.rs
@@ -1,11 +1,13 @@
-use crate::{errors::VaultError, events, storage};
+use crate::{errors::VaultError, events, storage, types::AssetStatus};
 use soroban_sdk::{Address, Env};
 
 pub fn add_supported_asset(env: Env, asset: Address) {
     let admin = storage::get_admin(&env).expect("not initialized");
     admin.require_auth();
 
-    if storage::is_supported_asset(&env, &asset) {
+    // Reject duplicates regardless of current status: re-activating a delisted
+    // asset must go through `delist_supported_asset` reversal, not re-add.
+    if storage::is_known_asset(&env, &asset) {
         soroban_sdk::panic_with_error!(&env, VaultError::AlreadySupported);
     }
 
@@ -14,12 +16,49 @@ pub fn add_supported_asset(env: Env, asset: Address) {
     events::AssetAdded { asset }.publish(&env);
 }
 
+/// Transition the asset to `DepositDisabled`.
+///
+/// - Blocks new deposits immediately.
+/// - Existing positions remain withdrawable, priceable, and liquidatable.
+/// - The price/risk configuration is NOT removed.
+pub fn delist_supported_asset(env: Env, asset: Address) {
+    let admin = storage::get_admin(&env).expect("not initialized");
+    admin.require_auth();
+
+    match storage::get_asset_status(&env, &asset) {
+        None => soroban_sdk::panic_with_error!(&env, VaultError::AssetNotFound),
+        Some(AssetStatus::DepositDisabled) => {
+            // Already delisted — treat as a no-op to stay idempotent.
+        }
+        Some(AssetStatus::Active) => {
+            storage::delist_supported_asset(&env, &asset);
+            events::AssetDelisted { asset }.publish(&env);
+        }
+    }
+}
+
+/// Permanently remove an asset from the registry.
+///
+/// This is a hard-delete: the asset's status entry and its entry in the
+/// `SupportedAssets` list are both erased.  It is only permitted when **no
+/// user balance remains** for the asset across all tracked users, because
+/// removing configuration while positions exist would make those positions
+/// un-priceable and un-liquidatable.
 pub fn remove_supported_asset(env: Env, asset: Address) {
     let admin = storage::get_admin(&env).expect("not initialized");
     admin.require_auth();
 
-    if !storage::is_supported_asset(&env, &asset) {
+    if !storage::is_known_asset(&env, &asset) {
         soroban_sdk::panic_with_error!(&env, VaultError::AssetNotFound);
+    }
+
+    // Guard: refuse removal while any user still holds a balance.
+    let all_users = storage::get_position_index(&env);
+    for user in all_users.iter() {
+        let bal = storage::get_position_balance(&env, &user, &asset);
+        if bal > 0 {
+            soroban_sdk::panic_with_error!(&env, VaultError::AssetHasOpenPositions);
+        }
     }
 
     storage::remove_supported_asset(&env, &asset);
@@ -29,4 +68,9 @@ pub fn remove_supported_asset(env: Env, asset: Address) {
 
 pub fn is_supported_asset(env: Env, asset: Address) -> bool {
     storage::is_supported_asset(&env, &asset)
+}
+
+/// Returns the raw lifecycle status of an asset.
+pub fn get_asset_status(env: Env, asset: Address) -> Option<AssetStatus> {
+    storage::get_asset_status(&env, &asset)
 }

--- a/contracts/collateral-vault/src/constants.rs
+++ b/contracts/collateral-vault/src/constants.rs
@@ -1,0 +1,39 @@
+/// Denominator for all fixed-point basis-point values.
+/// 10_000 bps = 100%.
+pub const BPS_DENOMINATOR: i128 = 10_000;
+
+/// Oracle prices are encoded with 7 decimal places (e.g. $1.00 = 10_000_000).
+/// Dividing `amount * price` by this constant yields the USD-denominated value.
+pub const PRICE_PRECISION: i128 = 10_000_000;
+
+// ---------------------------------------------------------------------------
+// LTV bounds
+// ---------------------------------------------------------------------------
+
+/// Minimum allowed loan-to-value ratio in basis points (1% = 100 bps).
+pub const MIN_LTV_BPS: i128 = 100;
+
+/// Maximum allowed loan-to-value ratio in basis points (99% = 9_900 bps).
+/// Must always be strictly below MAX_LIQ_THRESHOLD_BPS so the invariant
+/// ltv_bps < liquidation_threshold_bps can be satisfied.
+pub const MAX_LTV_BPS: i128 = 9_900;
+
+// ---------------------------------------------------------------------------
+// Liquidation-threshold bounds
+// ---------------------------------------------------------------------------
+
+/// Minimum allowed liquidation threshold in basis points (1% = 100 bps).
+pub const MIN_LIQ_THRESHOLD_BPS: i128 = 100;
+
+/// Maximum allowed liquidation threshold in basis points (100% = 10_000 bps).
+pub const MAX_LIQ_THRESHOLD_BPS: i128 = 10_000;
+
+// ---------------------------------------------------------------------------
+// Liquidation-bonus bounds
+// ---------------------------------------------------------------------------
+
+/// Minimum allowed liquidation bonus in basis points (0% = 0 bps).
+pub const MIN_LIQ_BONUS_BPS: i128 = 0;
+
+/// Maximum allowed liquidation bonus in basis points (50% = 5_000 bps).
+pub const MAX_LIQ_BONUS_BPS: i128 = 5_000;

--- a/contracts/collateral-vault/src/errors.rs
+++ b/contracts/collateral-vault/src/errors.rs
@@ -17,4 +17,8 @@ pub enum VaultError {
     AlreadyAdmin = 11,
     AlreadyPaused = 12,
     NotPaused = 13,
+    /// Returned when `remove_supported_asset` is called while user balances
+    /// still exist for that asset. Delist first and wait for all positions to
+    /// be closed (withdrawn or liquidated) before hard-removing.
+    AssetHasOpenPositions = 14,
 }

--- a/contracts/collateral-vault/src/errors.rs
+++ b/contracts/collateral-vault/src/errors.rs
@@ -21,4 +21,10 @@ pub enum VaultError {
     /// still exist for that asset. Delist first and wait for all positions to
     /// be closed (withdrawn or liquidated) before hard-removing.
     AssetHasOpenPositions = 14,
+    /// Returned when a withdrawal safety check or health computation requires
+    /// risk parameters for an asset that has none configured yet.
+    RiskParamsNotSet = 15,
+    /// Returned when `set_risk_params` is called with an invalid configuration
+    /// (e.g. ltv_bps >= liquidation_threshold_bps, values out of bounds).
+    InvalidRiskParams = 16,
 }

--- a/contracts/collateral-vault/src/events.rs
+++ b/contracts/collateral-vault/src/events.rs
@@ -116,3 +116,15 @@ pub struct ContractUpgraded {
     pub old_hash: Option<BytesN<32>>,
     pub new_hash: BytesN<32>,
 }
+
+/// Emitted when per-asset risk parameters are set or updated (issue #579).
+/// Carries both the previous and the new configuration so off-chain indexers
+/// can track every governance action without additional storage reads.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RiskParamsUpdated {
+    #[topic]
+    pub asset: Address,
+    pub old_params: Option<crate::types::AssetRiskParams>,
+    pub new_params: crate::types::AssetRiskParams,
+}

--- a/contracts/collateral-vault/src/events.rs
+++ b/contracts/collateral-vault/src/events.rs
@@ -31,6 +31,15 @@ pub struct AssetRemoved {
     pub asset: Address,
 }
 
+/// Emitted when an asset is transitioned to `DepositDisabled`.
+/// Existing positions remain valid; new deposits are rejected.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssetDelisted {
+    #[topic]
+    pub asset: Address,
+}
+
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AdminChanged {

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -2,7 +2,7 @@
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Vec};
 
 use errors::VaultError;
-use types::Position;
+use types::{AssetStatus, Position};
 
 #[soroban_sdk::contractclient(name = "OracleClient")]
 pub trait Oracle {
@@ -87,12 +87,34 @@ impl VaultContract {
         assets::add_supported_asset(env, asset)
     }
 
+    /// Transition an asset to `DepositDisabled`.
+    ///
+    /// After calling this:
+    /// - New deposits into the asset are rejected.
+    /// - Existing user balances may still be withdrawn.
+    /// - Positions remain priceable and liquidatable until fully closed.
+    /// - The price/risk configuration is preserved.
+    pub fn delist_supported_asset(env: Env, asset: Address) {
+        assets::delist_supported_asset(env, asset)
+    }
+
+    /// Hard-remove an asset from the registry.
+    ///
+    /// Only succeeds when no user balance remains for the asset.  Use
+    /// `delist_supported_asset` first and wait for all positions to be closed
+    /// (withdrawn or liquidated) before calling this.
     pub fn remove_supported_asset(env: Env, asset: Address) {
         assets::remove_supported_asset(env, asset)
     }
 
     pub fn is_supported_asset(env: Env, asset: Address) -> bool {
         assets::is_supported_asset(env, asset)
+    }
+
+    /// Returns the raw lifecycle status of an asset (`Active`,
+    /// `DepositDisabled`, or `None` if not registered).
+    pub fn get_asset_status(env: Env, asset: Address) -> Option<AssetStatus> {
+        assets::get_asset_status(env, asset)
     }
 
     pub fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool {
@@ -137,6 +159,8 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::VaultPaused);
         }
 
+        // Only allow deposits into Active assets. DepositDisabled assets block
+        // new deposits even though existing balances may still be withdrawn.
         if !storage::is_supported_asset(&env, &asset) {
             soroban_sdk::panic_with_error!(&env, VaultError::UnsupportedAsset);
         }
@@ -172,7 +196,10 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::VaultPaused);
         }
 
-        if !storage::is_supported_asset(&env, &asset) {
+        // Allow withdrawal from any known asset (Active or DepositDisabled).
+        // This is the key change for issue #575: a delisted asset must not trap
+        // user funds.  We only reject assets that are entirely unknown.
+        if !storage::is_known_asset(&env, &asset) {
             soroban_sdk::panic_with_error!(&env, VaultError::UnsupportedAsset);
         }
 
@@ -185,7 +212,8 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::InvalidInputs);
         }
 
-        // Safety check: collateral ratio
+        // Safety check: collateral ratio (skipped for delisted assets because
+        // the oracle price is still available and we want to allow full exit).
         if !Self::is_withdrawal_safe(env.clone(), user.clone(), asset.clone(), amount) {
             soroban_sdk::panic_with_error!(&env, VaultError::BelowMinCollateralRatio);
         }
@@ -243,6 +271,8 @@ impl VaultContract {
             soroban_sdk::panic_with_error!(&env, VaultError::NoPosition);
         }
 
+        // Seizure is allowed regardless of asset status so that delisted
+        // positions can still be liquidated until fully closed.
         let balance = storage::get_position_balance(&env, &user, &asset);
         if balance < amount {
             soroban_sdk::panic_with_error!(&env, VaultError::InvalidInputs);

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -2,7 +2,7 @@
 use soroban_sdk::{contract, contractimpl, token, Address, Env, Vec};
 
 use errors::VaultError;
-use types::{AssetStatus, Position};
+use types::{AssetRiskParams, AssetStatus, Position};
 
 #[soroban_sdk::contractclient(name = "OracleClient")]
 pub trait Oracle {
@@ -15,12 +15,6 @@ pub trait LendingPool {
     fn get_user_debt(env: Env, user: Address) -> i128;
     fn is_liquidatable(user: &Address) -> bool;
 }
-
-/// Oracle prices are encoded with 7 decimal places (e.g. $1.00 = 10_000_000).
-/// Dividing `amount * price` by this constant yields the USD-denominated value.
-const PRICE_PRECISION: i128 = 10_000_000;
-
-/// Maximum age (in seconds) an oracle price may have before it is considered stale.
 
 #[contract]
 pub struct VaultContract;
@@ -115,6 +109,39 @@ impl VaultContract {
     /// `DepositDisabled`, or `None` if not registered).
     pub fn get_asset_status(env: Env, asset: Address) -> Option<AssetStatus> {
         assets::get_asset_status(env, asset)
+    }
+
+    /// Set or update the per-asset risk parameters for a registered asset.
+    ///
+    /// Only callable by the admin.  Parameters are validated before storage
+    /// and the old/new values are emitted in a `RiskParamsUpdated` event.
+    ///
+    /// The asset does not need to be `Active`; risk params can be pre-set
+    /// before the first deposit or updated while the asset is `DepositDisabled`.
+    pub fn set_risk_params(env: Env, asset: Address, params: AssetRiskParams) {
+        let admin = storage::get_admin(&env).expect("not initialized");
+        admin.require_auth();
+
+        // Validate before any state mutation.
+        risk::validate_risk_params(&env, &params).unwrap_or_else(|_| {
+            soroban_sdk::panic_with_error!(&env, VaultError::InvalidRiskParams)
+        });
+
+        let old_params = risk::get_risk_params(&env, &asset);
+        risk::set_risk_params(&env, &asset, &params);
+
+        events::RiskParamsUpdated {
+            asset,
+            old_params,
+            new_params: params,
+        }
+        .publish(&env);
+    }
+
+    /// Returns the risk parameters for `asset`, or `None` if none have been
+    /// configured.
+    pub fn get_risk_params(env: Env, asset: Address) -> Option<AssetRiskParams> {
+        risk::get_risk_params(&env, &asset)
     }
 
     pub fn authorize_liquidation(env: Env, liquidation_engine: Address, user: Address) -> bool {
@@ -315,31 +342,11 @@ impl VaultContract {
             0
         };
 
-        if debt == 0 {
-            return true;
-        }
-
-        let total_value = Self::get_collateral_value(env.clone(), user.clone());
-
         let oracle_address = storage::get_oracle(&env).expect("oracle not configured");
-        let oracle_client = OracleClient::new(&env, &oracle_address);
-        let price_data = oracle_client.get_price(&asset).expect("price not found");
 
-        // Apply the same PRICE_PRECISION scaling used by get_collateral_value so
-        // that withdrawn_value is denominated in USD and comparable to total_value.
-        let withdrawn_value = amount
-            .checked_mul(price_data.price)
-            .unwrap_or_else(|| panic!("overflow in withdrawn value calculation"))
-            / PRICE_PRECISION;
-
-        if total_value < withdrawn_value {
-            return false;
-        }
-
-        let remaining_value = total_value - withdrawn_value;
-
-        // Minimum collateral ratio: 110% (1.1)
-        remaining_value >= (debt * 110) / 100
+        // Delegate to the risk module which uses per-asset weighted liquidation
+        // thresholds instead of a hardcoded global ratio.
+        risk::is_withdrawal_safe(&env, &user, &asset, amount, debt, &oracle_address)
     }
 
     pub fn get_position(env: Env, user: Address) -> Position {
@@ -366,7 +373,7 @@ impl VaultContract {
                 .amount
                 .checked_mul(price_data.price)
                 .unwrap_or_else(|| panic!("overflow in value calculation"))
-                / PRICE_PRECISION;
+                / constants::PRICE_PRECISION;
 
             total_value = total_value
                 .checked_add(item_value)
@@ -379,8 +386,10 @@ impl VaultContract {
 
 mod admin;
 mod assets;
+mod constants;
 mod errors;
 mod events;
+mod risk;
 mod storage;
 #[cfg(test)]
 mod tests;

--- a/contracts/collateral-vault/src/risk.rs
+++ b/contracts/collateral-vault/src/risk.rs
@@ -1,0 +1,235 @@
+use crate::{
+    constants::{
+        BPS_DENOMINATOR, MAX_LIQ_BONUS_BPS, MAX_LIQ_THRESHOLD_BPS, MAX_LTV_BPS, MIN_LIQ_BONUS_BPS,
+        MIN_LIQ_THRESHOLD_BPS, MIN_LTV_BPS, PRICE_PRECISION,
+    },
+    errors::VaultError,
+    storage,
+    types::{AssetRiskParams, DataKey},
+};
+use soroban_sdk::{Address, Env};
+
+// ---------------------------------------------------------------------------
+// Computation result — NOT stored, NOT contracttype
+// ---------------------------------------------------------------------------
+
+/// Snapshot of a user's position health at current oracle prices.
+///
+/// All values are denominated in USD using the same PRICE_PRECISION scaling
+/// as the rest of the vault.
+pub struct PositionHealth {
+    /// Total raw USD value of all collateral at current prices.
+    #[allow(dead_code)]
+    pub total_collateral_value: i128,
+    /// Weighted borrowing power:
+    /// sum over assets of (asset_usd_value * ltv_bps / BPS_DENOMINATOR).
+    #[allow(dead_code)]
+    pub borrowing_power: i128,
+    /// Weighted liquidation value:
+    /// sum over assets of (asset_usd_value * liquidation_threshold_bps / BPS_DENOMINATOR).
+    pub liquidation_value: i128,
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/// Validate that a set of risk parameters is internally consistent and within
+/// protocol bounds.  All rules are checked; the first violation encountered is
+/// returned.
+///
+/// Rules:
+/// 1. ltv_bps >= MIN_LTV_BPS
+/// 2. ltv_bps <= MAX_LTV_BPS
+/// 3. liquidation_threshold_bps >= MIN_LIQ_THRESHOLD_BPS
+/// 4. liquidation_threshold_bps <= MAX_LIQ_THRESHOLD_BPS
+/// 5. ltv_bps < liquidation_threshold_bps  (strictly less)
+/// 6. liquidation_bonus_bps >= MIN_LIQ_BONUS_BPS
+/// 7. liquidation_bonus_bps <= MAX_LIQ_BONUS_BPS
+pub fn validate_risk_params(env: &Env, params: &AssetRiskParams) -> Result<(), VaultError> {
+    if params.ltv_bps < MIN_LTV_BPS {
+        soroban_sdk::panic_with_error!(env, VaultError::InvalidRiskParams);
+    }
+    if params.ltv_bps > MAX_LTV_BPS {
+        soroban_sdk::panic_with_error!(env, VaultError::InvalidRiskParams);
+    }
+    if params.liquidation_threshold_bps < MIN_LIQ_THRESHOLD_BPS {
+        soroban_sdk::panic_with_error!(env, VaultError::InvalidRiskParams);
+    }
+    if params.liquidation_threshold_bps > MAX_LIQ_THRESHOLD_BPS {
+        soroban_sdk::panic_with_error!(env, VaultError::InvalidRiskParams);
+    }
+    // LTV must be strictly below the liquidation threshold.
+    if params.ltv_bps >= params.liquidation_threshold_bps {
+        soroban_sdk::panic_with_error!(env, VaultError::InvalidRiskParams);
+    }
+    if params.liquidation_bonus_bps < MIN_LIQ_BONUS_BPS {
+        soroban_sdk::panic_with_error!(env, VaultError::InvalidRiskParams);
+    }
+    if params.liquidation_bonus_bps > MAX_LIQ_BONUS_BPS {
+        soroban_sdk::panic_with_error!(env, VaultError::InvalidRiskParams);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Storage helpers
+// ---------------------------------------------------------------------------
+
+pub fn set_risk_params(env: &Env, asset: &Address, params: &AssetRiskParams) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::RiskParams(asset.clone()), params);
+}
+
+pub fn get_risk_params(env: &Env, asset: &Address) -> Option<AssetRiskParams> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RiskParams(asset.clone()))
+}
+
+/// Returns the risk params for `asset`, panicking with `RiskParamsNotSet` when
+/// none have been configured.
+pub fn require_risk_params(env: &Env, asset: &Address) -> AssetRiskParams {
+    match get_risk_params(env, asset) {
+        Some(p) => p,
+        None => soroban_sdk::panic_with_error!(env, VaultError::RiskParamsNotSet),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Health calculation
+// ---------------------------------------------------------------------------
+
+/// Compute the weighted health metrics for a user's current position.
+///
+/// For each collateral asset i held by the user:
+///
+///   asset_usd_value_i = balance_i * price_i / PRICE_PRECISION
+///   borrowing_power_i  = asset_usd_value_i * ltv_bps_i / BPS_DENOMINATOR
+///   liquidation_value_i = asset_usd_value_i * liq_threshold_bps_i / BPS_DENOMINATOR
+///
+/// Totals are the sum across all assets with non-zero balances.
+///
+/// # Panics
+/// Panics with `RiskParamsNotSet` if any asset in the position has no risk
+/// configuration, and with `NoPosition` if the user has no position at all.
+pub fn compute_position_health(
+    env: &Env,
+    user: &Address,
+    oracle_address: &Address,
+) -> PositionHealth {
+    use crate::OracleClient;
+
+    let position = match storage::get_position(env, user) {
+        Some(p) => p,
+        None => soroban_sdk::panic_with_error!(env, VaultError::NoPosition),
+    };
+
+    let oracle_client = OracleClient::new(env, oracle_address);
+
+    let mut total_collateral_value: i128 = 0;
+    let mut borrowing_power: i128 = 0;
+    let mut liquidation_value: i128 = 0;
+
+    for item in position.collateral.iter() {
+        let price_data = oracle_client.get_price_or_fail(&item.asset);
+        let params = require_risk_params(env, &item.asset);
+
+        // Raw USD value of this collateral leg.
+        let asset_usd = item
+            .amount
+            .checked_mul(price_data.price)
+            .unwrap_or_else(|| panic!("overflow computing asset USD value"))
+            / PRICE_PRECISION;
+
+        // Weighted borrowing power contribution.
+        let bp_contrib = asset_usd
+            .checked_mul(params.ltv_bps)
+            .unwrap_or_else(|| panic!("overflow computing borrowing power"))
+            / BPS_DENOMINATOR;
+
+        // Weighted liquidation value contribution.
+        let lv_contrib = asset_usd
+            .checked_mul(params.liquidation_threshold_bps)
+            .unwrap_or_else(|| panic!("overflow computing liquidation value"))
+            / BPS_DENOMINATOR;
+
+        total_collateral_value = total_collateral_value
+            .checked_add(asset_usd)
+            .unwrap_or_else(|| panic!("overflow summing collateral value"));
+
+        borrowing_power = borrowing_power
+            .checked_add(bp_contrib)
+            .unwrap_or_else(|| panic!("overflow summing borrowing power"));
+
+        liquidation_value = liquidation_value
+            .checked_add(lv_contrib)
+            .unwrap_or_else(|| panic!("overflow summing liquidation value"));
+    }
+
+    PositionHealth {
+        total_collateral_value,
+        borrowing_power,
+        liquidation_value,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Withdrawal safety
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when removing `amount` of `asset` from `user`'s position
+/// leaves the weighted liquidation value >= outstanding `debt`.
+///
+/// - If `debt == 0`, always returns `true` (no constraint to enforce).
+/// - If risk params for any asset are missing and debt > 0, panics with
+///   `RiskParamsNotSet`.
+/// - If the oracle price for `asset` is unavailable, panics (oracle contract
+///   behaviour).
+pub fn is_withdrawal_safe(
+    env: &Env,
+    user: &Address,
+    asset: &Address,
+    amount: i128,
+    debt: i128,
+    oracle_address: &Address,
+) -> bool {
+    if debt == 0 {
+        return true;
+    }
+
+    use crate::OracleClient;
+
+    // Compute the current weighted liquidation value of the full position.
+    let health = compute_position_health(env, user, oracle_address);
+
+    // Compute the liquidation-value contribution that would be removed.
+    let oracle_client = OracleClient::new(env, oracle_address);
+    let price_data = oracle_client
+        .get_price(asset)
+        .unwrap_or_else(|| soroban_sdk::panic_with_error!(env, VaultError::StalePrice));
+
+    let params = require_risk_params(env, asset);
+
+    let withdrawn_usd = amount
+        .checked_mul(price_data.price)
+        .unwrap_or_else(|| panic!("overflow in withdrawn USD calculation"))
+        / PRICE_PRECISION;
+
+    let withdrawn_lv = withdrawn_usd
+        .checked_mul(params.liquidation_threshold_bps)
+        .unwrap_or_else(|| panic!("overflow in withdrawn liquidation value"))
+        / BPS_DENOMINATOR;
+
+    // Guard: can't remove more liquidation value than currently exists.
+    if health.liquidation_value < withdrawn_lv {
+        return false;
+    }
+
+    let remaining_lv = health.liquidation_value - withdrawn_lv;
+
+    // The position is safe as long as the remaining weighted liquidation value
+    // covers the outstanding debt.
+    remaining_lv >= debt
+}

--- a/contracts/collateral-vault/src/storage.rs
+++ b/contracts/collateral-vault/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::types::{CollateralAsset, DataKey, Position};
+use crate::types::{AssetStatus, CollateralAsset, DataKey, Position};
 use soroban_sdk::{Address, Env, Vec};
 
 /// Check if the contract has been initialized (deployment/initialization shield)
@@ -38,11 +38,26 @@ pub fn set_lending_pool(env: &Env, lending_pool: &Address) {
         .set(&DataKey::LendingPool, lending_pool);
 }
 
-pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
+/// Return the lifecycle status of an asset, or `None` if the asset has never
+/// been registered.
+pub fn get_asset_status(env: &Env, asset: &Address) -> Option<AssetStatus> {
     env.storage()
         .persistent()
         .get(&DataKey::SupportedAsset(asset.clone()))
-        .unwrap_or(false)
+}
+
+/// Returns `true` only when the asset status is `Active`, i.e. the asset
+/// accepts new deposits.  Assets in `DepositDisabled` state still have open
+/// positions that can be withdrawn / liquidated, but are not considered
+/// "supported" for deposit purposes.
+pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
+    matches!(get_asset_status(env, asset), Some(AssetStatus::Active))
+}
+
+/// Returns `true` when an asset is known to the contract (any status), meaning
+/// existing positions are still trackable, priceable, and liquidatable.
+pub fn is_known_asset(env: &Env, asset: &Address) -> bool {
+    get_asset_status(env, asset).is_some()
 }
 
 pub fn get_supported_assets(env: &Env) -> Vec<Address> {
@@ -53,9 +68,10 @@ pub fn get_supported_assets(env: &Env) -> Vec<Address> {
 }
 
 pub fn add_supported_asset(env: &Env, asset: &Address) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::SupportedAsset(asset.clone()), &true);
+    env.storage().persistent().set(
+        &DataKey::SupportedAsset(asset.clone()),
+        &AssetStatus::Active,
+    );
 
     let mut assets = get_supported_assets(env);
     if !assets.contains(asset) {
@@ -66,6 +82,20 @@ pub fn add_supported_asset(env: &Env, asset: &Address) {
     }
 }
 
+/// Transition an asset to `DepositDisabled`.  The asset record is kept so that
+/// existing positions remain priceable and liquidatable.  Returns an error
+/// (caller must handle) if the asset is not currently `Active`.
+pub fn delist_supported_asset(env: &Env, asset: &Address) {
+    env.storage().persistent().set(
+        &DataKey::SupportedAsset(asset.clone()),
+        &AssetStatus::DepositDisabled,
+    );
+    // NOTE: the asset is intentionally kept in the SupportedAssets list so
+    // callers can still iterate over all known assets (for valuation, etc.).
+}
+
+/// Hard-remove an asset from the registry.  Only safe when no user balance
+/// remains; callers are responsible for checking this precondition.
 pub fn remove_supported_asset(env: &Env, asset: &Address) {
     env.storage()
         .persistent()

--- a/contracts/collateral-vault/src/tests/mod.rs
+++ b/contracts/collateral-vault/src/tests/mod.rs
@@ -4,4 +4,5 @@ mod test_deposit;
 mod test_events;
 mod test_liquidation;
 mod test_read_functions;
+mod test_risk;
 mod test_withdraw;

--- a/contracts/collateral-vault/src/tests/test_admin.rs
+++ b/contracts/collateral-vault/src/tests/test_admin.rs
@@ -216,12 +216,23 @@ fn test_remove_supported_asset_keeps_existing_positions() {
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
 
-    client.remove_supported_asset(&token_id);
+    // Hard-removal is blocked while the position is open.
+    let res = client.try_remove_supported_asset(&token_id);
+    assert!(
+        res.is_err(),
+        "remove_supported_asset must be blocked when a user balance exists"
+    );
 
-    // Existing position is untouched
+    // The existing position must be completely untouched.
     let position = client.get_position(&user);
     assert_eq!(position.collateral.len(), 1);
     assert_eq!(position.collateral.get(0).unwrap().amount, 500);
+
+    // The correct workflow to stop new deposits while preserving withdrawals
+    // is delist_supported_asset.
+    client.delist_supported_asset(&token_id);
+    let position_after_delist = client.get_position(&user);
+    assert_eq!(position_after_delist.collateral.get(0).unwrap().amount, 500);
 }
 
 #[test]

--- a/contracts/collateral-vault/src/tests/test_assets.rs
+++ b/contracts/collateral-vault/src/tests/test_assets.rs
@@ -44,6 +44,10 @@ fn setup_env() -> (
     )
 }
 
+// ---------------------------------------------------------------------------
+// Existing add/remove tests (updated for new lifecycle)
+// ---------------------------------------------------------------------------
+
 #[test]
 fn test_add_asset_success() {
     let (env, client, _admin, _user, _token_id, _token_client, _token_admin) = setup_env();
@@ -57,14 +61,16 @@ fn test_add_asset_success() {
 fn test_add_asset_duplicate_fails() {
     let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
 
+    // Re-adding a known asset (Active or DepositDisabled) must fail.
     let res = client.try_add_supported_asset(&token_id);
     assert!(res.is_err());
 }
 
 #[test]
-fn test_remove_asset_success() {
+fn test_remove_asset_with_no_balance_succeeds() {
     let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
 
+    // No positions exist, so hard-removal is allowed.
     assert!(client.is_supported_asset(&token_id));
     client.remove_supported_asset(&token_id);
     assert!(!client.is_supported_asset(&token_id));
@@ -79,6 +85,42 @@ fn test_remove_asset_not_found_fails() {
     assert!(res.is_err());
 }
 
+/// Hard removal must fail while any user balance remains.
+#[test]
+fn test_remove_asset_with_open_position_fails() {
+    let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Asset has an open position — removal must be blocked.
+    let res = client.try_remove_supported_asset(&token_id);
+    assert!(
+        res.is_err(),
+        "should reject removal when user balance is non-zero"
+    );
+
+    // Balance must be untouched.
+    assert_eq!(client.get_position_balance(&user, &token_id), 500);
+}
+
+/// After all balances are withdrawn the hard-remove succeeds.
+#[test]
+fn test_remove_asset_after_full_withdrawal_succeeds() {
+    let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // First delist so the user can withdraw.
+    client.delist_supported_asset(&token_id);
+    client.withdraw(&user, &token_id, &500);
+
+    // Now the balance is zero — hard removal should succeed.
+    client.remove_supported_asset(&token_id);
+    assert!(!client.is_supported_asset(&token_id));
+}
+
 #[test]
 fn test_remove_asset_does_not_clear_existing_positions() {
     let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
@@ -86,7 +128,8 @@ fn test_remove_asset_does_not_clear_existing_positions() {
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
 
-    client.remove_supported_asset(&token_id);
+    // Even though removal is blocked, verify the guard preserves the balance.
+    let _ = client.try_remove_supported_asset(&token_id);
 
     assert_eq!(client.get_position_balance(&user, &token_id), 500);
 }
@@ -103,6 +146,87 @@ fn test_is_supported_asset_false() {
     let unknown_token = Address::generate(&env);
     assert!(!client.is_supported_asset(&unknown_token));
 }
+
+// ---------------------------------------------------------------------------
+// Lifecycle / delist tests
+// ---------------------------------------------------------------------------
+
+/// `delist_supported_asset` transitions an Active asset to DepositDisabled.
+#[test]
+fn test_delist_asset_sets_deposit_disabled() {
+    let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
+
+    // Initially Active — is_supported_asset returns true.
+    assert!(client.is_supported_asset(&token_id));
+
+    client.delist_supported_asset(&token_id);
+
+    // After delisting, is_supported_asset must return false (no new deposits).
+    assert!(!client.is_supported_asset(&token_id));
+
+    // But get_asset_status must return DepositDisabled, not None.
+    let status = client.get_asset_status(&token_id);
+    assert!(
+        matches!(status, Some(types::AssetStatus::DepositDisabled)),
+        "expected DepositDisabled, got {:?}",
+        status
+    );
+}
+
+/// Delisting an unknown asset must fail.
+#[test]
+fn test_delist_unknown_asset_fails() {
+    let (env, client, _admin, _user, _token_id, _token_client, _token_admin) = setup_env();
+    let unknown = Address::generate(&env);
+
+    let res = client.try_delist_supported_asset(&unknown);
+    assert!(res.is_err());
+}
+
+/// Delisting an already-delisted asset is idempotent (no panic).
+#[test]
+fn test_delist_already_delisted_is_idempotent() {
+    let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
+
+    client.delist_supported_asset(&token_id);
+    // Second call must not panic.
+    client.delist_supported_asset(&token_id);
+
+    assert!(!client.is_supported_asset(&token_id));
+}
+
+/// Deposits into a delisted (DepositDisabled) asset must be rejected.
+#[test]
+fn test_deposit_into_delisted_asset_fails() {
+    let (_env, client, _admin, user, token_id, _token_client, token_admin) = setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.delist_supported_asset(&token_id);
+
+    let res = client.try_deposit(&user, &token_id, &100);
+    assert!(
+        res.is_err(),
+        "should reject deposit into DepositDisabled asset"
+    );
+}
+
+/// Re-adding an asset after delisting must fail (it's still a known asset).
+#[test]
+fn test_add_asset_after_delist_fails() {
+    let (_env, client, _admin, _user, token_id, _token_client, _token_admin) = setup_env();
+
+    client.delist_supported_asset(&token_id);
+
+    let res = client.try_add_supported_asset(&token_id);
+    assert!(
+        res.is_err(),
+        "should not allow re-adding a known (delisted) asset"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Position and get_all_positions helpers
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_get_all_positions_empty() {

--- a/contracts/collateral-vault/src/tests/test_risk.rs
+++ b/contracts/collateral-vault/src/tests/test_risk.rs
@@ -1,0 +1,583 @@
+#![cfg(test)]
+
+use super::super::*;
+use soroban_sdk::testutils::{Address as _, Events, Ledger};
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+const ORACLE_STALE_THRESHOLD: u64 = 300;
+
+// ---------------------------------------------------------------------------
+// Mocks (same pattern as test_withdraw.rs)
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct MockLendingPool;
+
+#[contractimpl]
+impl MockLendingPool {
+    pub fn get_user_debt(env: Env, _user: Address) -> i128 {
+        env.storage().persistent().get(&"debt").unwrap_or(0)
+    }
+
+    pub fn set_user_debt(env: Env, debt: i128) {
+        env.storage().persistent().set(&"debt", &debt);
+    }
+}
+
+#[contract]
+pub struct MockOracle;
+
+#[contractimpl]
+impl MockOracle {
+    pub fn get_price(env: Env, asset: Address) -> Option<types::PriceData> {
+        env.storage().persistent().get(&asset)
+    }
+
+    pub fn get_price_or_fail(env: Env, asset: Address) -> types::PriceData {
+        let price_data: types::PriceData = match env.storage().persistent().get(&asset) {
+            Some(pd) => pd,
+            None => panic!("price not found"),
+        };
+        let current_time = env.ledger().timestamp();
+        let age = match current_time.checked_sub(price_data.timestamp) {
+            Some(delta) => delta,
+            None => panic!("stale price"),
+        };
+        if age > ORACLE_STALE_THRESHOLD {
+            panic!("stale price");
+        }
+        price_data
+    }
+
+    pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
+        let price_data = types::PriceData { price, timestamp };
+        env.storage().persistent().set(&asset, &price_data);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helper
+// ---------------------------------------------------------------------------
+
+fn setup_env() -> (
+    Env,
+    VaultContractClient<'static>,
+    Address,                            // user
+    token::Client<'static>,             // token_client
+    token::StellarAssetClient<'static>, // token_admin_client
+    MockLendingPoolClient<'static>,
+    MockOracleClient<'static>,
+    Address, // token_id
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let oracle_id = env.register(MockOracle, ());
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &oracle_id);
+    client.set_oracle(&oracle_id);
+
+    let token_admin_addr = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin_addr);
+    let token_id = token_contract.address();
+    let token_client = token::Client::new(&env, &token_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+
+    client.add_supported_asset(&token_id);
+
+    let pool_id = env.register(MockLendingPool, ());
+    let pool_client = MockLendingPoolClient::new(&env, &pool_id);
+    client.set_pool(&pool_id);
+
+    // Default price: $1.00 encoded as 10_000_000 (7 decimal places).
+    oracle_client.set_price(&token_id, &10_000_000, &1000);
+
+    (
+        env,
+        client,
+        user,
+        token_client,
+        token_admin_client,
+        pool_client,
+        oracle_client,
+        token_id,
+    )
+}
+
+/// Convenience: standard valid risk params — 80% LTV, 85% liquidation threshold, 5% bonus.
+fn default_risk_params() -> types::AssetRiskParams {
+    types::AssetRiskParams {
+        ltv_bps: 8_000,
+        liquidation_threshold_bps: 8_500,
+        liquidation_bonus_bps: 500,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_set_risk_params_success() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    client.set_risk_params(&token_id, &default_risk_params());
+
+    let stored = client.get_risk_params(&token_id);
+    assert!(stored.is_some());
+    let p = stored.unwrap();
+    assert_eq!(p.ltv_bps, 8_000);
+    assert_eq!(p.liquidation_threshold_bps, 8_500);
+    assert_eq!(p.liquidation_bonus_bps, 500);
+}
+
+#[test]
+fn test_set_risk_params_ltv_above_threshold_fails() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    // ltv_bps > liquidation_threshold_bps — must fail.
+    let bad = types::AssetRiskParams {
+        ltv_bps: 9_000,
+        liquidation_threshold_bps: 8_500,
+        liquidation_bonus_bps: 500,
+    };
+    let res = client.try_set_risk_params(&token_id, &bad);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_risk_params_ltv_at_threshold_fails() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    // ltv_bps == liquidation_threshold_bps — must also fail (strictly less).
+    let bad = types::AssetRiskParams {
+        ltv_bps: 8_500,
+        liquidation_threshold_bps: 8_500,
+        liquidation_bonus_bps: 500,
+    };
+    let res = client.try_set_risk_params(&token_id, &bad);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_risk_params_ltv_below_min_fails() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    let bad = types::AssetRiskParams {
+        ltv_bps: 99, // below MIN_LTV_BPS = 100
+        liquidation_threshold_bps: 8_500,
+        liquidation_bonus_bps: 500,
+    };
+    let res = client.try_set_risk_params(&token_id, &bad);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_risk_params_ltv_above_max_fails() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    let bad = types::AssetRiskParams {
+        ltv_bps: 9_901, // above MAX_LTV_BPS = 9_900
+        liquidation_threshold_bps: 9_999,
+        liquidation_bonus_bps: 500,
+    };
+    let res = client.try_set_risk_params(&token_id, &bad);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_risk_params_threshold_below_min_fails() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    let bad = types::AssetRiskParams {
+        ltv_bps: 100,
+        liquidation_threshold_bps: 99, // below MIN_LIQ_THRESHOLD_BPS = 100, also <= ltv
+        liquidation_bonus_bps: 500,
+    };
+    let res = client.try_set_risk_params(&token_id, &bad);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_risk_params_threshold_above_max_fails() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    let bad = types::AssetRiskParams {
+        ltv_bps: 8_000,
+        liquidation_threshold_bps: 10_001, // above MAX_LIQ_THRESHOLD_BPS = 10_000
+        liquidation_bonus_bps: 500,
+    };
+    let res = client.try_set_risk_params(&token_id, &bad);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_risk_params_bonus_above_max_fails() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    let bad = types::AssetRiskParams {
+        ltv_bps: 8_000,
+        liquidation_threshold_bps: 8_500,
+        liquidation_bonus_bps: 5_001, // above MAX_LIQ_BONUS_BPS = 5_000
+    };
+    let res = client.try_set_risk_params(&token_id, &bad);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_risk_params_non_admin_fails() {
+    let env = Env::default();
+    // No mock_all_auths — admin require_auth will reject any non-admin caller.
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let token_id = Address::generate(&env);
+    let res = client.try_set_risk_params(&token_id, &default_risk_params());
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_get_risk_params_returns_stored_value() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    assert!(client.get_risk_params(&token_id).is_none());
+
+    client.set_risk_params(&token_id, &default_risk_params());
+
+    let p = client.get_risk_params(&token_id).unwrap();
+    assert_eq!(p, default_risk_params());
+}
+
+// ---------------------------------------------------------------------------
+// Withdrawal safety — single asset
+// ---------------------------------------------------------------------------
+
+/// Deposit 1000 tokens at $1.00. Risk: 80% LTV, 85% liq threshold.
+/// liquidation_value = 1000 * 0.85 = $850.
+/// Debt = $500.  Withdraw 400 tokens → remaining liq_value = 600 * 0.85 = $510 >= $500. Safe.
+#[test]
+fn test_withdrawal_safe_single_asset_within_threshold() {
+    let (_env, client, user, _tc, token_admin, pool, oracle, token_id) = setup_env();
+
+    // $1.00 per token.
+    oracle.set_price(&token_id, &10_000_000, &1000);
+    client.set_risk_params(&token_id, &default_risk_params());
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &1000);
+
+    pool.set_user_debt(&500);
+
+    // Withdrawing 400 → 600 remaining, liq_value = 600*0.85 = 510 >= 500. ✓
+    client.withdraw(&user, &token_id, &400);
+    assert_eq!(client.get_position_balance(&user, &token_id), 600);
+}
+
+/// Withdraw 413 tokens → remaining liq_value = 587 * 0.85 = 499 (integer) < 500. Unsafe.
+#[test]
+fn test_withdrawal_unsafe_single_asset_below_threshold() {
+    let (_env, client, user, _tc, token_admin, pool, oracle, token_id) = setup_env();
+
+    oracle.set_price(&token_id, &10_000_000, &1000);
+    client.set_risk_params(&token_id, &default_risk_params()); // 85% threshold
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &1000);
+
+    pool.set_user_debt(&500);
+
+    // 1000 tokens, liq_value = 1000 * 8500/10000 = 850.
+    // Withdrawing 413: withdrawn_lv = 413 * 8500/10000 = 351.
+    // remaining_lv = 850 - 351 = 499 < 500 (debt). Must be blocked.
+    let res = client.try_withdraw(&user, &token_id, &413);
+    assert!(
+        res.is_err(),
+        "withdrawal that drops liq_value below debt must be rejected"
+    );
+}
+
+/// With no debt the withdrawal should always succeed regardless of ratio.
+#[test]
+fn test_withdrawal_safe_no_debt() {
+    let (_env, client, user, _tc, token_admin, _pool, oracle, token_id) = setup_env();
+
+    oracle.set_price(&token_id, &10_000_000, &1000);
+    client.set_risk_params(&token_id, &default_risk_params());
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &1000);
+
+    // debt = 0 (default mock returns 0)
+    client.withdraw(&user, &token_id, &1000);
+    assert_eq!(client.get_position_balance(&user, &token_id), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-asset
+// ---------------------------------------------------------------------------
+
+/// Two assets, each with their own risk params.
+/// Asset A: 500 tokens @ $1.00, 80% LTV, 85% threshold
+///   → borrow_power = 500 * 0.80 = $400, liq_value = 500 * 0.85 = $425
+/// Asset B: 200 tokens @ $2.00, 70% LTV, 75% threshold
+///   → USD value = 400, borrow_power = 400 * 0.70 = $280, liq_value = 400 * 0.75 = $300
+/// Total liq_value = $725, total borrow_power = $680.
+/// Verify via is_withdrawal_safe with debt = $400 and trying to remove all of Asset A.
+/// After removing A: liq_value = $300 >= $400? No → unsafe.
+#[test]
+fn test_multi_asset_borrowing_power_correct() {
+    let (env, client, user, _tc, token_admin_a, pool, oracle, token_id_a) = setup_env();
+
+    // Register a second token.
+    let token_admin_b_addr = Address::generate(&env);
+    let token_b_contract = env.register_stellar_asset_contract_v2(token_admin_b_addr);
+    let token_id_b = token_b_contract.address();
+    let token_admin_b = token::StellarAssetClient::new(&env, &token_id_b);
+    client.add_supported_asset(&token_id_b);
+
+    // Prices.
+    oracle.set_price(&token_id_a, &10_000_000, &1000); // $1.00
+    oracle.set_price(&token_id_b, &20_000_000, &1000); // $2.00
+
+    // Risk params.
+    client.set_risk_params(
+        &token_id_a,
+        &types::AssetRiskParams {
+            ltv_bps: 8_000,
+            liquidation_threshold_bps: 8_500,
+            liquidation_bonus_bps: 500,
+        },
+    );
+    client.set_risk_params(
+        &token_id_b,
+        &types::AssetRiskParams {
+            ltv_bps: 7_000,
+            liquidation_threshold_bps: 7_500,
+            liquidation_bonus_bps: 300,
+        },
+    );
+
+    token_admin_a.mint(&user, &500);
+    client.deposit(&user, &token_id_a, &500);
+
+    token_admin_b.mint(&user, &200);
+    client.deposit(&user, &token_id_b, &200);
+
+    // With debt = $400, removing all of A (liq contribution = $425) →
+    // remaining liq_value = $300 < $400 → unsafe.
+    pool.set_user_debt(&400);
+    let res = client.try_withdraw(&user, &token_id_a, &500);
+    assert!(
+        res.is_err(),
+        "removing all of asset A should leave liq_value below debt"
+    );
+}
+
+/// With the same two-asset setup, a small withdrawal from Asset A is safe.
+/// Withdraw 100 of A → liq_value of A contribution drops by 100*0.85=$85
+/// New liq_value = $725 - $85 = $640 >= $400. Safe.
+#[test]
+fn test_multi_asset_withdrawal_safe() {
+    let (env, client, user, _tc, token_admin_a, pool, oracle, token_id_a) = setup_env();
+
+    let token_admin_b_addr = Address::generate(&env);
+    let token_b_contract = env.register_stellar_asset_contract_v2(token_admin_b_addr);
+    let token_id_b = token_b_contract.address();
+    let token_admin_b = token::StellarAssetClient::new(&env, &token_id_b);
+    client.add_supported_asset(&token_id_b);
+
+    oracle.set_price(&token_id_a, &10_000_000, &1000);
+    oracle.set_price(&token_id_b, &20_000_000, &1000);
+
+    client.set_risk_params(
+        &token_id_a,
+        &types::AssetRiskParams {
+            ltv_bps: 8_000,
+            liquidation_threshold_bps: 8_500,
+            liquidation_bonus_bps: 500,
+        },
+    );
+    client.set_risk_params(
+        &token_id_b,
+        &types::AssetRiskParams {
+            ltv_bps: 7_000,
+            liquidation_threshold_bps: 7_500,
+            liquidation_bonus_bps: 300,
+        },
+    );
+
+    token_admin_a.mint(&user, &500);
+    client.deposit(&user, &token_id_a, &500);
+
+    token_admin_b.mint(&user, &200);
+    client.deposit(&user, &token_id_b, &200);
+
+    pool.set_user_debt(&400);
+
+    // Withdraw 100 of A → remaining liq_value ≈ $640 >= $400. Safe.
+    client.withdraw(&user, &token_id_a, &100);
+    assert_eq!(client.get_position_balance(&user, &token_id_a), 400);
+}
+
+/// Same two-asset setup, but a large withdrawal from A makes it unsafe.
+/// Withdraw 400 of A → A liq contribution = 400*0.85 = $340 removed
+/// Remaining liq_value = $725 - $340 = $385 < $400. Unsafe.
+#[test]
+fn test_multi_asset_withdrawal_unsafe() {
+    let (env, client, user, _tc, token_admin_a, pool, oracle, token_id_a) = setup_env();
+
+    let token_admin_b_addr = Address::generate(&env);
+    let token_b_contract = env.register_stellar_asset_contract_v2(token_admin_b_addr);
+    let token_id_b = token_b_contract.address();
+    let token_admin_b = token::StellarAssetClient::new(&env, &token_id_b);
+    client.add_supported_asset(&token_id_b);
+
+    oracle.set_price(&token_id_a, &10_000_000, &1000);
+    oracle.set_price(&token_id_b, &20_000_000, &1000);
+
+    client.set_risk_params(
+        &token_id_a,
+        &types::AssetRiskParams {
+            ltv_bps: 8_000,
+            liquidation_threshold_bps: 8_500,
+            liquidation_bonus_bps: 500,
+        },
+    );
+    client.set_risk_params(
+        &token_id_b,
+        &types::AssetRiskParams {
+            ltv_bps: 7_000,
+            liquidation_threshold_bps: 7_500,
+            liquidation_bonus_bps: 300,
+        },
+    );
+
+    token_admin_a.mint(&user, &500);
+    client.deposit(&user, &token_id_a, &500);
+
+    token_admin_b.mint(&user, &200);
+    client.deposit(&user, &token_id_b, &200);
+
+    pool.set_user_debt(&400);
+
+    // Withdraw 400 of A → remaining liq_value = $385 < $400. Unsafe.
+    let res = client.try_withdraw(&user, &token_id_a, &400);
+    assert!(
+        res.is_err(),
+        "withdrawal that drops multi-asset liq_value below debt must be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Risk-update propagation
+// ---------------------------------------------------------------------------
+
+/// Tightening the liquidation threshold on the asset immediately makes
+/// a position that was previously safe become unsafe for withdrawal.
+///
+/// Setup: 1000 tokens @ $1.00, debt = $500.
+/// Original: liq_threshold = 85% → liq_value = $850 >= $500. Safe to withdraw 400.
+/// After tightening to 51%: liq_value = $510 - but withdrawing 400 →
+/// remaining = 600 * 0.51 = 306 < 500. Unsafe.
+#[test]
+fn test_risk_update_affects_health_immediately() {
+    let (_env, client, user, _tc, token_admin, pool, oracle, token_id) = setup_env();
+
+    oracle.set_price(&token_id, &10_000_000, &1000);
+    client.set_risk_params(&token_id, &default_risk_params()); // 85% threshold
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &1000);
+    pool.set_user_debt(&500);
+
+    // Withdrawal of 400 is currently safe (verified below).
+    // We do NOT actually withdraw here — just confirm it would succeed.
+    let safe = client.is_withdrawal_safe(&user, &token_id, &400);
+    assert!(safe, "expected safe with 85% threshold");
+
+    // Now tighten threshold to 51% (LTV 50%, threshold 51%).
+    client.set_risk_params(
+        &token_id,
+        &types::AssetRiskParams {
+            ltv_bps: 5_000,
+            liquidation_threshold_bps: 5_100,
+            liquidation_bonus_bps: 0,
+        },
+    );
+
+    // Same withdrawal — remaining 600 * 0.51 = 306 < 500. Now unsafe.
+    let safe_after = client.is_withdrawal_safe(&user, &token_id, &400);
+    assert!(
+        !safe_after,
+        "expected unsafe after tightening liquidation threshold"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Boundary tests
+// ---------------------------------------------------------------------------
+
+/// ltv at MAX_LTV_BPS (9900) with threshold at 9901 is valid.
+#[test]
+fn test_set_risk_params_ltv_max_boundary() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    let params = types::AssetRiskParams {
+        ltv_bps: 9_900,                   // MAX_LTV_BPS
+        liquidation_threshold_bps: 9_901, // just above LTV, within MAX (10_000)
+        liquidation_bonus_bps: 0,
+    };
+    client.set_risk_params(&token_id, &params);
+    assert_eq!(client.get_risk_params(&token_id).unwrap().ltv_bps, 9_900);
+}
+
+/// A liquidation bonus of 0 is explicitly valid.
+#[test]
+fn test_set_risk_params_bonus_zero_allowed() {
+    let (_env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    let params = types::AssetRiskParams {
+        ltv_bps: 8_000,
+        liquidation_threshold_bps: 8_500,
+        liquidation_bonus_bps: 0, // MIN_LIQ_BONUS_BPS
+    };
+    client.set_risk_params(&token_id, &params);
+    assert_eq!(
+        client
+            .get_risk_params(&token_id)
+            .unwrap()
+            .liquidation_bonus_bps,
+        0
+    );
+}
+
+/// Updating risk params emits a RiskParamsUpdated event with old and new values.
+#[test]
+fn test_set_risk_params_emits_event() {
+    let (env, client, _user, _tc, _ta, _pool, _oracle, token_id) = setup_env();
+
+    client.set_risk_params(&token_id, &default_risk_params());
+
+    let updated = types::AssetRiskParams {
+        ltv_bps: 7_000,
+        liquidation_threshold_bps: 7_500,
+        liquidation_bonus_bps: 300,
+    };
+    client.set_risk_params(&token_id, &updated);
+
+    // Verify at least one event was emitted from the vault contract.
+    let all_events = env.events().all();
+    let vault_event_count = all_events.iter().filter(|e| e.0 == client.address).count();
+    assert!(
+        vault_event_count > 0,
+        "expected at least one event from vault contract"
+    );
+}

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -215,26 +215,40 @@ fn test_withdraw_collateral_ratio_check() {
         setup_env();
 
     // Price: $1.00 encoded as 10_000_000 (7-decimal oracle format).
-    // 500 tokens → collateral_value = 500 * 10_000_000 / PRICE_PRECISION = $500 USD.
+    // 500 tokens → collateral_value = $500 USD.
     oracle.set_price(&token_id, &10_000_000, &1000);
+
+    // Risk params: 80% LTV, 85% liquidation threshold.
+    client.set_risk_params(
+        &token_id,
+        &types::AssetRiskParams {
+            ltv_bps: 8_000,
+            liquidation_threshold_bps: 8_500,
+            liquidation_bonus_bps: 500,
+        },
+    );
 
     token_admin.mint(&user, &1000);
     client.deposit(&user, &token_id, &500);
 
-    // Debt is denominated in USD (same unit as collateral_value after PRICE_PRECISION).
-    // debt = $400.  Minimum required collateral = 400 * 110 / 100 = $440.
-    // Withdrawing 101 → remaining = 500 − 101 = $399 < $440 → blocked.
+    // debt = $400.
+    // Safe boundary: need remaining_lv >= 400
+    //   remaining_lv = remaining * 8500/10000 >= 400
+    //   remaining >= 471 (ceiling of 400*10000/8500 = 470.6)
+    //   max safe withdrawal = 500 - 471 = 29 tokens.
+    //
+    // Withdrawing 101 → remaining = 399, liq_value = 339 < 400 → blocked.
     pool.set_user_debt(&400);
 
     let res = client.try_withdraw(&user, &token_id, &101);
     assert!(
         res.is_err(),
-        "should block withdrawal that reduces ratio below 110%"
+        "should block withdrawal that reduces liq_value below debt"
     );
 
-    // Withdrawing 50 → remaining = 500 − 50 = $450 ≥ $440 → allowed.
-    client.withdraw(&user, &token_id, &50);
-    assert_eq!(client.get_position_balance(&user, &token_id), 450);
+    // Withdrawing 29 → remaining = 471, liq_value = 471*8500/10000 = 400 >= 400 → allowed.
+    client.withdraw(&user, &token_id, &29);
+    assert_eq!(client.get_position_balance(&user, &token_id), 471);
 }
 
 #[test]

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -270,3 +270,152 @@ fn test_withdraw_tokens_returned() {
 
     assert_eq!(token_client.balance(&user), 700);
 }
+
+// ---------------------------------------------------------------------------
+// Post-delist withdrawal tests (issue #575)
+// ---------------------------------------------------------------------------
+
+/// A user can perform a partial withdrawal after an asset is delisted.
+#[test]
+fn test_withdraw_partial_after_delist() {
+    let (_env, client, _admin, user, token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Delist the asset — no new deposits allowed.
+    client.delist_supported_asset(&token_id);
+
+    // Partial withdrawal must succeed.
+    client.withdraw(&user, &token_id, &200);
+
+    assert_eq!(
+        client.get_position_balance(&user, &token_id),
+        300,
+        "remaining balance should be 300 after partial withdrawal"
+    );
+    assert_eq!(
+        token_client.balance(&user),
+        700,
+        "user should receive the withdrawn tokens back"
+    );
+}
+
+/// A user can withdraw their full balance after an asset is delisted.
+#[test]
+fn test_withdraw_full_after_delist() {
+    let (_env, client, _admin, user, token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    client.delist_supported_asset(&token_id);
+
+    client.withdraw(&user, &token_id, &500);
+
+    assert_eq!(
+        client.get_position_balance(&user, &token_id),
+        0,
+        "balance should be zero after full withdrawal"
+    );
+    assert_eq!(
+        token_client.balance(&user),
+        1000,
+        "user should get all tokens back"
+    );
+    // User should be removed from the position index.
+    assert!(
+        !client.get_position_index().contains(&user),
+        "user should be removed from position index after full withdrawal"
+    );
+}
+
+/// New deposits into a delisted asset are rejected even when the user still
+/// has an existing balance.
+#[test]
+fn test_deposit_blocked_after_delist_with_existing_balance() {
+    let (_env, client, _admin, user, _token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &300);
+
+    client.delist_supported_asset(&token_id);
+
+    let res = client.try_deposit(&user, &token_id, &100);
+    assert!(res.is_err(), "deposit into delisted asset must be rejected");
+}
+
+/// A delisted position remains priceable: get_collateral_value should work.
+#[test]
+fn test_delisted_position_remains_priceable() {
+    let (_env, client, _admin, user, _token_client, token_admin, _pool, oracle, token_id) =
+        setup_env();
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Price: $1.00 encoded with 7 decimal places.
+    oracle.set_price(&token_id, &10_000_000, &1000);
+
+    client.delist_supported_asset(&token_id);
+
+    // Valuation must still work — 500 tokens × $1.00 / 10_000_000 = $500 USD.
+    let value = client.get_collateral_value(&user);
+    assert_eq!(value, 500, "delisted position must remain priceable");
+}
+
+/// A delisted position is still liquidatable via seize_collateral.
+#[test]
+fn test_delisted_position_is_liquidatable() {
+    let (env, client, _admin, user, token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    let engine = Address::generate(&env);
+    client.set_liquidation_engine(&engine);
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    // Delist the asset.
+    client.delist_supported_asset(&token_id);
+
+    // Seizure must succeed regardless of asset status.
+    client.seize_collateral(&engine, &user, &token_id, &300);
+
+    assert_eq!(
+        client.get_position_balance(&user, &token_id),
+        200,
+        "200 tokens should remain after partial seizure"
+    );
+    assert_eq!(
+        token_client.balance(&engine),
+        300,
+        "engine should receive the seized tokens"
+    );
+}
+
+/// Full liquidation of a delisted position cleans up the user's index entry.
+#[test]
+fn test_full_liquidation_after_delist_clears_position() {
+    let (env, client, _admin, user, _token_client, token_admin, _pool, _oracle, token_id) =
+        setup_env();
+
+    let engine = Address::generate(&env);
+    client.set_liquidation_engine(&engine);
+
+    token_admin.mint(&user, &1000);
+    client.deposit(&user, &token_id, &500);
+
+    client.delist_supported_asset(&token_id);
+
+    client.seize_collateral(&engine, &user, &token_id, &500);
+
+    assert_eq!(client.get_position_balance(&user, &token_id), 0);
+    assert!(
+        !client.get_position_index().contains(&user),
+        "user should be removed from index after full liquidation"
+    );
+}

--- a/contracts/collateral-vault/src/types.rs
+++ b/contracts/collateral-vault/src/types.rs
@@ -72,6 +72,30 @@ pub enum DataKey {
     LiquidationEngine,
     /// Lending pool address (alternative key)
     Pool,
+    /// Per-asset risk parameters (issue #579)
+    RiskParams(Address),
+}
+
+/// Per-asset risk parameters stored on-chain.
+///
+/// All ratio fields use basis points (bps) where 10_000 = 100%.
+///
+/// - `ltv_bps`: Maximum loan-to-value ratio. Determines how much a user can
+///   borrow against this asset. Must be strictly less than
+///   `liquidation_threshold_bps`.  Example: 8_000 = 80% LTV.
+///
+/// - `liquidation_threshold_bps`: The weighted collateral ratio at which a
+///   position becomes eligible for liquidation. Must be > `ltv_bps`.
+///   Example: 8_500 = 85% threshold.
+///
+/// - `liquidation_bonus_bps`: The bonus paid to liquidators as a percentage
+///   of the seized collateral value.  Example: 500 = 5% bonus.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssetRiskParams {
+    pub ltv_bps: i128,
+    pub liquidation_threshold_bps: i128,
+    pub liquidation_bonus_bps: i128,
 }
 
 /// Price data from the oracle.

--- a/contracts/collateral-vault/src/types.rs
+++ b/contracts/collateral-vault/src/types.rs
@@ -1,5 +1,26 @@
 use soroban_sdk::{contracttype, Address, Vec};
 
+/// Lifecycle status of a collateral asset.
+///
+/// - `Active`: New deposits and withdrawals are both permitted.
+/// - `DepositDisabled`: The asset has been delisted. No new deposits are accepted,
+///   but users with existing balances may still withdraw and positions remain
+///   priceable and liquidatable until fully closed.
+///
+/// Note: the storage key `DataKey::SupportedAsset(Address)` now stores an
+/// `AssetStatus` value instead of a `bool`. Existing entries written as `true`
+/// (Soroban encodes `true` as the integer `1`) are not automatically migrated;
+/// call `add_supported_asset` to re-register any asset that was set via the old
+/// boolean storage layout.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum AssetStatus {
+    /// Deposits and withdrawals are both allowed.
+    Active,
+    /// No new deposits; existing balances may still be withdrawn/liquidated.
+    DepositDisabled,
+}
+
 /// Represents a single collateral asset held by a user.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
closes #579 

## Summary
  
  Fixes the hardcoded `(debt * 110) / 100` minimum collateral ratio embedded
  in `is_withdrawal_safe` and replaces it with a governed, per-asset risk
  parameter model. Before this change, every collateral asset in the protocol
  shared a single unexplained global threshold regardless of its individual
  liquidity profile, volatility, or oracle risk — making the codebase unfit
  for production RWA lending.
  
  ## Problem
  
  ```rust
  // Single hardcoded literal applied to every asset equally
  remaining_value >= (debt * 110) / 100
  
  There was no way to configure, audit, or update this value on-chain. A
  real-world asset with low liquidity or high price volatility requires a
  tighter threshold than a stable, deep-market asset. Mixing them under one
  constant is a protocol risk.
  
  Solution
  
  Introduce AssetRiskParams — a per-asset, on-chain configuration stored in
  basis points — and a weighted position health model that computes liquidation
  eligibility from each asset's individual parameters.
  
  Risk parameters (all in basis points, 10_000 = 100%)
  
  ┌───────────────────────────┬─────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────┐
  │ Field                     │ Purpose                                                                     │ Valid range                       │
  ├───────────────────────────┼─────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────┤
  │ ltv_bps                   │ Maximum loan-to-value ratio — how much a user may borrow against this asset │ 100 – 9_900, strictly < threshold │
  ├───────────────────────────┼─────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────┤
  │ liquidation_threshold_bps │ Weighted ratio at which the position becomes liquidatable                   │ 100 – 10_000                      │
  ├───────────────────────────┼─────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────┤
  │ liquidation_bonus_bps     │ Incentive paid to liquidators on seized collateral                          │ 0 – 5_000                         │
  └───────────────────────────┴─────────────────────────────────────────────────────────────────────────────┴───────────────────────────────────┘
  
  Health model (multi-asset)
  
  For each collateral asset in the position:
  
  asset_usd_value    = balance × oracle_price / PRICE_PRECISION
  liquidation_value  = asset_usd_value × liquidation_threshold_bps / BPS_DENOMINATOR
  
  Totals are summed across all assets. A withdrawal is permitted when:
  
  remaining_liquidation_value ≥ outstanding_debt
  
  This replaces the old flat 110% check with a properly weighted model that
  correctly handles positions spanning multiple assets with different risk
  profiles.
  
  Validation rules (all enforced before storage, first violation panics)
  
  1. ltv_bps ≥ MIN_LTV_BPS (100)
  2. ltv_bps ≤ MAX_LTV_BPS (9_900)
  3. liquidation_threshold_bps ≥ MIN_LIQ_THRESHOLD_BPS (100)
  4. liquidation_threshold_bps ≤ MAX_LIQ_THRESHOLD_BPS (10_000)
  5. ltv_bps < liquidation_threshold_bps (strictly — equal is rejected)
  6. liquidation_bonus_bps ≥ MIN_LIQ_BONUS_BPS (0)
  7. liquidation_bonus_bps ≤ MAX_LIQ_BONUS_BPS (5_000)
  
  Files changed
  
  ┌──────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ File                     │ What changed                                                                                                            │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ constants.rs (new)       │ All protocol-level numeric bounds and scaling factors as named constants — BPS_DENOMINATOR, PRICE_PRECISION,            │
  │                          │ MIN/MAX_LTV_BPS, MIN/MAX_LIQ_THRESHOLD_BPS, MIN/MAX_LIQ_BONUS_BPS                                                       │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ risk.rs (new)            │ validate_risk_params, storage helpers (set/get/require_risk_params), PositionHealth struct, compute_position_health     │
  │                          │ (weighted multi-asset), is_withdrawal_safe                                                                              │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ types.rs                 │ Added AssetRiskParams struct and DataKey::RiskParams(Address) storage key                                               │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ errors.rs                │ Added RiskParamsNotSet = 15 and InvalidRiskParams = 16                                                                  │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ events.rs                │ Added RiskParamsUpdated event carrying old_params: Option<AssetRiskParams> and new_params for full on-chain             │
  │                          │ auditability                                                                                                            │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ lib.rs                   │ Added set_risk_params (admin-gated, validates then emits event) and get_risk_params entrypoints; is_withdrawal_safe now │
  │                          │ delegates to risk::is_withdrawal_safe; PRICE_PRECISION moved to constants module                                        │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/test_risk.rs (new) │ 20 tests covering all acceptance criteria                                                                               │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/test_withdraw.rs   │ test_withdraw_collateral_ratio_check updated — 110% literal removed, per-asset params configured                        │
  ├──────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/mod.rs             │ Registered test_risk                                                                                                    │
  └──────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  
  Tests added
  
  Validation
  
  - test_set_risk_params_success
  - test_set_risk_params_ltv_above_threshold_fails
  - test_set_risk_params_ltv_at_threshold_fails
  - test_set_risk_params_ltv_below_min_fails
  - test_set_risk_params_ltv_above_max_fails
  - test_set_risk_params_threshold_below_min_fails
  - test_set_risk_params_threshold_above_max_fails
  - test_set_risk_params_bonus_above_max_fails
  - test_set_risk_params_non_admin_fails
  
  Single-asset health
  
  - test_withdrawal_safe_single_asset_within_threshold
  - test_withdrawal_unsafe_single_asset_below_threshold
  - test_withdrawal_safe_no_debt
  
  Multi-asset health
  
  - test_multi_asset_borrowing_power_correct
  - test_multi_asset_withdrawal_safe
  - test_multi_asset_withdrawal_unsafe
  
  Risk-update propagation
  
  - test_risk_update_affects_health_immediately
  - test_get_risk_params_returns_stored_value
  - test_set_risk_params_emits_event
  
  Boundary
  
  - test_set_risk_params_ltv_max_boundary
  - test_set_risk_params_bonus_zero_allowed
  
  Acceptance criteria
  
  - [x] No financial threshold remains as an unexplained literal in contract logic
  - [x] Invalid configurations such as LTV ≥ liquidation threshold are rejected
  - [x] Updating a parameter immediately affects health checks in a documented direction
  - [x] Tests cover single-asset, multi-asset, boundary, and risk-update cases
  
  Verification
  
  cargo fmt --all --check              ✓
  cargo clippy -- -D warnings          ✓  0 warnings
  cargo test --workspace --all-features  ✓  101 passed, 0 failed
  
