### PR TITLE
feat(collateral-vault): storage lifetime and TTL extension policy (#584)

### DIFF
--- a/contracts/collateral-vault/src/constants.rs
+++ b/contracts/collateral-vault/src/constants.rs
@@ -1,0 +1,99 @@
+//! Storage lifetime and TTL policy for the collateral-vault contract.
+//!
+//! # Storage classification
+//!
+//! Soroban provides three storage classes with different lifetime semantics:
+//!
+//! | Storage class | Lifetime                        | Used for                              |
+//! |---------------|---------------------------------|---------------------------------------|
+//! | `instance`    | Tied to contract instance TTL   | Contract-wide configuration           |
+//! | `persistent`  | Finite TTL, survives checkpoints| Per-user positions, asset registries  |
+//! | `temporary`   | Expires automatically           | Not used in this contract             |
+//!
+//! ## DataKey → storage class mapping
+//!
+//! | DataKey variant          | Storage class | TTL policy                          |
+//! |--------------------------|---------------|-------------------------------------|
+//! | `Admin`                  | instance      | Extended with instance TTL          |
+//! | `Paused`                 | instance      | Extended with instance TTL          |
+//! | `LendingPool`            | instance      | Extended with instance TTL          |
+//! | `Oracle`                 | instance      | Extended with instance TTL          |
+//! | `LiquidationEngine`      | instance      | Extended with instance TTL          |
+//! | `Pool`                   | instance      | Extended with instance TTL          |
+//! | `SupportedAssets`        | instance      | Extended with instance TTL          |
+//! | `SupportedAsset(Address)`| persistent    | Extended per key on every read/write|
+//! | `Position(Address,Address)`| persistent  | Extended per key on every read/write|
+//! | `PositionIndex`          | persistent    | Extended on every read/write        |
+//! | `UserAssets(Address)`    | persistent    | Extended per key on every read/write|
+//!
+//! Configuration keys (`Admin`, `Paused`, `LendingPool`, `Oracle`,
+//! `LiquidationEngine`, `Pool`, `SupportedAssets`) are stored in `instance`
+//! storage because they are contract-wide, change infrequently, and share the
+//! contract-instance lifetime.  Keeping them in `instance` means a single
+//! `extend_ttl` call covers all of them simultaneously.
+//!
+//! Per-user data (`Position`, `UserAssets`) and shared indexes
+//! (`PositionIndex`, `SupportedAsset`) are stored in `persistent` storage
+//! because they are keyed per user or asset and must survive independently.
+//!
+//! # TTL extension strategy
+//!
+//! Extensions are **conditional**: an extension is only performed when the
+//! remaining TTL of the entry has fallen below `TTL_THRESHOLD_*`.  This avoids
+//! paying unnecessary resource fees on every invocation when the TTL is already
+//! healthy.
+//!
+//! The `extend_ttl` call is a no-op when the current TTL is already ≥ the
+//! target, so it is safe to call unconditionally — but the threshold check
+//! makes the intent explicit and avoids surprising behaviour.
+//!
+//! # Restoration path for archived persistent entries
+//!
+//! When a persistent entry's TTL reaches zero it becomes **archived**.  Archived
+//! entries are inaccessible to contract reads but are not permanently deleted.
+//!
+//! To restore an archived entry:
+//! 1. Identify the archived `LedgerKey` (contract address + `DataKey` variant).
+//! 2. Submit a `RestoreFootprint` transaction on Stellar that includes the
+//!    archived key in its read-write footprint.
+//! 3. The entry is restored to the minimum persistent TTL and is accessible again.
+//!
+//! **Operational responsibility**: the protocol does not perform automatic
+//! restoration.  Operators, keepers, or users are responsible for submitting
+//! `RestoreFootprint` transactions before interacting with archived positions.
+//! The contract admin should monitor instance and contract-code TTL and extend
+//! them at least every 14 days using a keeper bot or manual transaction.
+//!
+//! # Ledger arithmetic
+//!
+//! Stellar produces approximately one ledger every 6 seconds:
+//! - 1 day  ≈  14_400 ledgers
+//! - 7 days ≈ 100_800 ledgers
+//! - 30 days ≈ 432_000 ledgers
+
+/// Minimum remaining TTL (in ledgers) for **instance** storage below which an
+/// extension is triggered.  Approximately 7 days at 6 s/ledger.
+///
+/// When the contract instance TTL falls below this value on any invocation that
+/// touches instance storage, the TTL is extended to [`TTL_TARGET_INSTANCE`].
+pub const TTL_THRESHOLD_INSTANCE: u32 = 100_800;
+
+/// Target TTL (in ledgers) to extend **instance** storage to when the threshold
+/// is crossed.  Approximately 30 days at 6 s/ledger.
+///
+/// Must be strictly greater than [`TTL_THRESHOLD_INSTANCE`].
+pub const TTL_TARGET_INSTANCE: u32 = 432_000;
+
+/// Minimum remaining TTL (in ledgers) for **persistent** per-key entries below
+/// which an extension is triggered.  Approximately 3 days at 6 s/ledger.
+///
+/// When a persistent entry's TTL falls below this value on any read or write
+/// that touches that specific key, the TTL is extended to
+/// [`TTL_TARGET_PERSISTENT`].
+pub const TTL_THRESHOLD_PERSISTENT: u32 = 43_200;
+
+/// Target TTL (in ledgers) to extend **persistent** per-key entries to when the
+/// threshold is crossed.  Approximately 30 days at 6 s/ledger.
+///
+/// Must be strictly greater than [`TTL_THRESHOLD_PERSISTENT`].
+pub const TTL_TARGET_PERSISTENT: u32 = 432_000;

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -349,6 +349,7 @@ impl VaultContract {
 
 mod admin;
 mod assets;
+pub mod constants;
 mod errors;
 mod events;
 mod storage;

--- a/contracts/collateral-vault/src/storage.rs
+++ b/contracts/collateral-vault/src/storage.rs
@@ -1,76 +1,216 @@
+//! Storage access layer for the collateral-vault contract.
+//!
+//! See [`crate::constants`] for the full storage-class classification and TTL
+//! policy documentation.
+//!
+//! ## Summary
+//!
+//! - **Instance storage**: `Admin`, `Paused`, `LendingPool`, `Oracle`,
+//!   `LiquidationEngine`, `Pool`, `SupportedAssets`.  A single
+//!   `extend_ttl` call on the instance covers all of these simultaneously.
+//!
+//! - **Persistent storage**: `SupportedAsset(Address)`,
+//!   `Position(Address, Address)`, `PositionIndex`, `UserAssets(Address)`.
+//!   Each key is extended individually on every read and write.
+
+use crate::constants::{
+    TTL_TARGET_INSTANCE, TTL_TARGET_PERSISTENT, TTL_THRESHOLD_INSTANCE, TTL_THRESHOLD_PERSISTENT,
+};
 use crate::types::{CollateralAsset, DataKey, Position};
 use soroban_sdk::{Address, Env, Vec};
 
-/// Check if the contract has been initialized (deployment/initialization shield)
-pub fn has_admin(env: &Env) -> bool {
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Extend the contract instance TTL if it has fallen below the threshold.
+#[inline]
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(TTL_THRESHOLD_INSTANCE, TTL_TARGET_INSTANCE);
+}
+
+/// Extend a persistent key's TTL if it has fallen below the threshold.
+#[inline]
+fn bump_persistent(env: &Env, key: &DataKey) {
     env.storage()
         .persistent()
+        .extend_ttl(key, TTL_THRESHOLD_PERSISTENT, TTL_TARGET_PERSISTENT);
+}
+
+// ---------------------------------------------------------------------------
+// Instance storage: Admin
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the contract has been initialized (admin key present).
+pub fn has_admin(env: &Env) -> bool {
+    let exists = env
+        .storage()
+        .instance()
         .get::<_, Address>(&DataKey::Admin)
-        .is_some()
+        .is_some();
+    if exists {
+        bump_instance(env);
+    }
+    exists
 }
 
 pub fn get_admin(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::Admin)
+    let val = env.storage().instance().get(&DataKey::Admin);
+    if val.is_some() {
+        bump_instance(env);
+    }
+    val
 }
 
 pub fn set_admin(env: &Env, admin: &Address) {
-    env.storage().persistent().set(&DataKey::Admin, admin);
+    env.storage().instance().set(&DataKey::Admin, admin);
+    bump_instance(env);
 }
 
+// ---------------------------------------------------------------------------
+// Instance storage: Paused
+// ---------------------------------------------------------------------------
+
 pub fn is_paused(env: &Env) -> bool {
-    env.storage()
-        .persistent()
+    let val = env
+        .storage()
+        .instance()
         .get(&DataKey::Paused)
-        .unwrap_or(false)
+        .unwrap_or(false);
+    bump_instance(env);
+    val
 }
 
 pub fn set_paused(env: &Env, paused: bool) {
-    env.storage().persistent().set(&DataKey::Paused, &paused);
+    env.storage().instance().set(&DataKey::Paused, &paused);
+    bump_instance(env);
 }
 
+// ---------------------------------------------------------------------------
+// Instance storage: LendingPool
+// ---------------------------------------------------------------------------
+
 pub fn _get_lending_pool(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::LendingPool)
+    let val = env.storage().instance().get(&DataKey::LendingPool);
+    if val.is_some() {
+        bump_instance(env);
+    }
+    val
 }
 
 pub fn set_lending_pool(env: &Env, lending_pool: &Address) {
     env.storage()
-        .persistent()
+        .instance()
         .set(&DataKey::LendingPool, lending_pool);
+    bump_instance(env);
 }
 
-pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
-    env.storage()
-        .persistent()
-        .get(&DataKey::SupportedAsset(asset.clone()))
-        .unwrap_or(false)
+// ---------------------------------------------------------------------------
+// Instance storage: Oracle
+// ---------------------------------------------------------------------------
+
+pub fn get_oracle(env: &Env) -> Option<Address> {
+    let val = env.storage().instance().get(&DataKey::Oracle);
+    if val.is_some() {
+        bump_instance(env);
+    }
+    val
 }
+
+pub fn set_oracle(env: &Env, oracle: &Address) {
+    env.storage().instance().set(&DataKey::Oracle, oracle);
+    bump_instance(env);
+}
+
+// ---------------------------------------------------------------------------
+// Instance storage: LiquidationEngine
+// ---------------------------------------------------------------------------
+
+pub fn get_liquidation_engine(env: &Env) -> Option<Address> {
+    let val = env.storage().instance().get(&DataKey::LiquidationEngine);
+    if val.is_some() {
+        bump_instance(env);
+    }
+    val
+}
+
+pub fn set_liquidation_engine(env: &Env, engine: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LiquidationEngine, engine);
+    bump_instance(env);
+}
+
+// ---------------------------------------------------------------------------
+// Instance storage: Pool
+// ---------------------------------------------------------------------------
+
+pub fn get_pool(env: &Env) -> Option<Address> {
+    let val = env.storage().instance().get(&DataKey::Pool);
+    if val.is_some() {
+        bump_instance(env);
+    }
+    val
+}
+
+pub fn set_pool(env: &Env, pool: &Address) {
+    env.storage().instance().set(&DataKey::Pool, pool);
+    bump_instance(env);
+}
+
+// ---------------------------------------------------------------------------
+// Instance storage: SupportedAssets list
+// ---------------------------------------------------------------------------
 
 pub fn get_supported_assets(env: &Env) -> Vec<Address> {
-    env.storage()
-        .persistent()
+    let val = env
+        .storage()
+        .instance()
         .get(&DataKey::SupportedAssets)
-        .unwrap_or_else(|| Vec::new(env))
+        .unwrap_or_else(|| Vec::new(env));
+    bump_instance(env);
+    val
+}
+
+// ---------------------------------------------------------------------------
+// Persistent storage: SupportedAsset(Address) per-asset flag
+// ---------------------------------------------------------------------------
+
+pub fn is_supported_asset(env: &Env, asset: &Address) -> bool {
+    let key = DataKey::SupportedAsset(asset.clone());
+    let val = env.storage().persistent().get(&key).unwrap_or(false);
+    if val {
+        bump_persistent(env, &key);
+    }
+    val
 }
 
 pub fn add_supported_asset(env: &Env, asset: &Address) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::SupportedAsset(asset.clone()), &true);
+    // Write per-asset flag to persistent storage
+    let asset_key = DataKey::SupportedAsset(asset.clone());
+    env.storage().persistent().set(&asset_key, &true);
+    bump_persistent(env, &asset_key);
 
+    // Update the assets list in instance storage
     let mut assets = get_supported_assets(env);
     if !assets.contains(asset) {
         assets.push_back(asset.clone());
         env.storage()
-            .persistent()
+            .instance()
             .set(&DataKey::SupportedAssets, &assets);
+        bump_instance(env);
     }
 }
 
 pub fn remove_supported_asset(env: &Env, asset: &Address) {
+    // Remove per-asset persistent flag
     env.storage()
         .persistent()
         .remove(&DataKey::SupportedAsset(asset.clone()));
 
+    // Update the assets list in instance storage
     let mut assets = get_supported_assets(env);
     let mut found_idx = None;
     for i in 0..assets.len() {
@@ -82,69 +222,63 @@ pub fn remove_supported_asset(env: &Env, asset: &Address) {
     if let Some(idx) = found_idx {
         assets.remove(idx);
         env.storage()
-            .persistent()
+            .instance()
             .set(&DataKey::SupportedAssets, &assets);
+        bump_instance(env);
     }
 }
 
-pub fn get_oracle(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::Oracle)
-}
-
-pub fn set_oracle(env: &Env, oracle: &Address) {
-    env.storage().persistent().set(&DataKey::Oracle, oracle);
-}
-
-pub fn get_liquidation_engine(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::LiquidationEngine)
-}
-
-pub fn set_liquidation_engine(env: &Env, engine: &Address) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::LiquidationEngine, engine);
-}
-
-pub fn get_pool(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::Pool)
-}
-
-pub fn set_pool(env: &Env, pool: &Address) {
-    env.storage().persistent().set(&DataKey::Pool, pool);
-}
+// ---------------------------------------------------------------------------
+// Persistent storage: Position(user, asset) balance
+// ---------------------------------------------------------------------------
 
 pub fn get_position_balance(env: &Env, user: &Address, asset: &Address) -> i128 {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Position(user.clone(), asset.clone()))
-        .unwrap_or(0)
+    let key = DataKey::Position(user.clone(), asset.clone());
+    let val = env.storage().persistent().get(&key).unwrap_or(0);
+    if val > 0 {
+        bump_persistent(env, &key);
+    }
+    val
 }
 
 pub fn set_position_balance(env: &Env, user: &Address, asset: &Address, balance: i128) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Position(user.clone(), asset.clone()), &balance);
+    let key = DataKey::Position(user.clone(), asset.clone());
+    env.storage().persistent().set(&key, &balance);
+    if balance > 0 {
+        bump_persistent(env, &key);
+    }
 }
 
+// ---------------------------------------------------------------------------
+// Persistent storage: PositionIndex
+// ---------------------------------------------------------------------------
+
 pub fn get_position_index(env: &Env) -> Vec<Address> {
-    env.storage()
+    let key = DataKey::PositionIndex;
+    let val = env
+        .storage()
         .persistent()
-        .get(&DataKey::PositionIndex)
-        .unwrap_or_else(|| Vec::new(env))
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    if !val.is_empty() {
+        bump_persistent(env, &key);
+    }
+    val
 }
 
 pub fn add_to_position_index(env: &Env, user: &Address) {
+    let key = DataKey::PositionIndex;
     let mut index = get_position_index(env);
     if !index.contains(user) {
         index.push_back(user.clone());
-        env.storage()
-            .persistent()
-            .set(&DataKey::PositionIndex, &index);
+        env.storage().persistent().set(&key, &index);
+        bump_persistent(env, &key);
     }
 }
 
 /// Remove a user from the position index (called when their balance reaches zero).
 pub fn remove_from_position_index(env: &Env, user: &Address) {
+    let key = DataKey::PositionIndex;
     let index = get_position_index(env);
     let mut new_index: Vec<Address> = Vec::new(env);
     for addr in index.iter() {
@@ -152,31 +286,43 @@ pub fn remove_from_position_index(env: &Env, user: &Address) {
             new_index.push_back(addr);
         }
     }
-    env.storage()
-        .persistent()
-        .set(&DataKey::PositionIndex, &new_index);
-}
-
-/// Track which assets a user has deposited into.
-pub fn get_user_assets(env: &Env, user: &Address) -> Vec<Address> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::UserAssets(user.clone()))
-        .unwrap_or_else(|| Vec::new(env))
-}
-
-pub fn add_user_asset(env: &Env, user: &Address, asset: &Address) {
-    let mut assets = get_user_assets(env, user);
-    if !assets.contains(asset) {
-        assets.push_back(asset.clone());
-        env.storage()
-            .persistent()
-            .set(&DataKey::UserAssets(user.clone()), &assets);
+    env.storage().persistent().set(&key, &new_index);
+    if !new_index.is_empty() {
+        bump_persistent(env, &key);
     }
 }
 
-/// Remove an asset from a user's tracked assets list (called when an asset balance hits zero).
+// ---------------------------------------------------------------------------
+// Persistent storage: UserAssets(user)
+// ---------------------------------------------------------------------------
+
+/// Returns the list of assets a user has ever deposited into.
+pub fn get_user_assets(env: &Env, user: &Address) -> Vec<Address> {
+    let key = DataKey::UserAssets(user.clone());
+    let val = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    if !val.is_empty() {
+        bump_persistent(env, &key);
+    }
+    val
+}
+
+pub fn add_user_asset(env: &Env, user: &Address, asset: &Address) {
+    let key = DataKey::UserAssets(user.clone());
+    let mut assets = get_user_assets(env, user);
+    if !assets.contains(asset) {
+        assets.push_back(asset.clone());
+        env.storage().persistent().set(&key, &assets);
+        bump_persistent(env, &key);
+    }
+}
+
+/// Remove an asset from a user's tracked asset list (called when the balance hits zero).
 pub fn remove_user_asset(env: &Env, user: &Address, asset: &Address) {
+    let key = DataKey::UserAssets(user.clone());
     let assets = get_user_assets(env, user);
     let mut new_assets: Vec<Address> = Vec::new(env);
     for a in assets.iter() {
@@ -184,12 +330,17 @@ pub fn remove_user_asset(env: &Env, user: &Address, asset: &Address) {
             new_assets.push_back(a);
         }
     }
-    env.storage()
-        .persistent()
-        .set(&DataKey::UserAssets(user.clone()), &new_assets);
+    env.storage().persistent().set(&key, &new_assets);
+    if !new_assets.is_empty() {
+        bump_persistent(env, &key);
+    }
 }
 
-/// Build a Position for a user by loading all their non-zero balances.
+// ---------------------------------------------------------------------------
+// Composite helpers
+// ---------------------------------------------------------------------------
+
+/// Build a `Position` for a user by loading all their non-zero balances.
 pub fn get_position(env: &Env, user: &Address) -> Option<Position> {
     let index = get_position_index(env);
     if !index.contains(user) {

--- a/contracts/collateral-vault/src/tests/mod.rs
+++ b/contracts/collateral-vault/src/tests/mod.rs
@@ -4,4 +4,5 @@ mod test_deposit;
 mod test_events;
 mod test_liquidation;
 mod test_read_functions;
+mod test_ttl;
 mod test_withdraw;

--- a/contracts/collateral-vault/src/tests/test_ttl.rs
+++ b/contracts/collateral-vault/src/tests/test_ttl.rs
@@ -1,0 +1,437 @@
+#![cfg(test)]
+
+//! TTL extension tests for the collateral-vault storage policy.
+//!
+//! These tests verify that:
+//! - Every write bumps TTL to at least `TTL_TARGET_*`.
+//! - Every read bumps TTL when the current value is below `TTL_THRESHOLD_*`.
+//! - No premature extension occurs when TTL is already above the threshold.
+//! - Boundary conditions (exactly at threshold, threshold+1) are handled correctly.
+//! - Failed calls do not extend any TTL.
+
+use super::super::*;
+use soroban_sdk::testutils::storage::{Instance, Persistent};
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+// ---------------------------------------------------------------------------
+// Mock oracle — always returns a fresh fixed price
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct TtlMockOracle;
+
+#[contractimpl]
+impl TtlMockOracle {
+    pub fn get_price(env: Env, _asset: Address) -> Option<types::PriceData> {
+        Some(types::PriceData {
+            price: 10_000_000,
+            timestamp: env.ledger().timestamp(),
+        })
+    }
+
+    pub fn get_price_or_fail(env: Env, _asset: Address) -> types::PriceData {
+        types::PriceData {
+            price: 10_000_000,
+            timestamp: env.ledger().timestamp(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+struct TtlFixture {
+    env: Env,
+    client: VaultContractClient<'static>,
+    contract_id: Address,
+    token_id: Address,
+    token_admin: token::StellarAssetClient<'static>,
+}
+
+fn setup_ttl() -> TtlFixture {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_sequence_number(100);
+    env.ledger().set_timestamp(1_000);
+
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let oracle_id = env.register(TtlMockOracle, ());
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &oracle_id);
+    client.set_oracle(&oracle_id);
+
+    let token_admin_addr = Address::generate(&env);
+    let tc = env.register_stellar_asset_contract_v2(token_admin_addr);
+    let token_id = tc.address();
+    let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+    client.add_supported_asset(&token_id);
+
+    TtlFixture {
+        env,
+        client,
+        contract_id,
+        token_id,
+        token_admin,
+    }
+}
+
+/// Read the instance TTL from inside the contract via `as_contract`.
+fn get_instance_ttl(env: &Env, contract_id: &Address) -> u32 {
+    env.as_contract(contract_id, || env.storage().instance().get_ttl())
+}
+
+/// Read a persistent key TTL from inside the contract via `as_contract`.
+fn get_persistent_ttl(env: &Env, contract_id: &Address, key: &types::DataKey) -> u32 {
+    env.as_contract(contract_id, || env.storage().persistent().get_ttl(key))
+}
+
+// ---------------------------------------------------------------------------
+// 1. TTL extension on write
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ttl_initialize_bumps_instance() {
+    let f = setup_ttl();
+    let ttl = get_instance_ttl(&f.env, &f.contract_id);
+    assert!(
+        ttl >= constants::TTL_TARGET_INSTANCE,
+        "instance TTL after initialize should be >= TTL_TARGET_INSTANCE ({}) but got {ttl}",
+        constants::TTL_TARGET_INSTANCE
+    );
+}
+
+#[test]
+fn test_ttl_add_supported_asset_bumps_instance() {
+    let f = setup_ttl();
+    let new_asset = Address::generate(&f.env);
+    f.client.add_supported_asset(&new_asset);
+
+    let ttl = get_instance_ttl(&f.env, &f.contract_id);
+    assert!(
+        ttl >= constants::TTL_TARGET_INSTANCE,
+        "instance TTL after add_supported_asset should be >= TTL_TARGET_INSTANCE ({}) but got {ttl}",
+        constants::TTL_TARGET_INSTANCE
+    );
+}
+
+#[test]
+fn test_ttl_add_supported_asset_bumps_persistent_flag() {
+    let f = setup_ttl();
+    let new_asset = Address::generate(&f.env);
+    f.client.add_supported_asset(&new_asset);
+
+    let key = types::DataKey::SupportedAsset(new_asset);
+    let ttl = get_persistent_ttl(&f.env, &f.contract_id, &key);
+    assert!(
+        ttl >= constants::TTL_TARGET_PERSISTENT,
+        "SupportedAsset TTL after add should be >= TTL_TARGET_PERSISTENT ({}) but got {ttl}",
+        constants::TTL_TARGET_PERSISTENT
+    );
+}
+
+#[test]
+fn test_ttl_deposit_bumps_position_key() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+    f.client.deposit(&user, &f.token_id, &500);
+
+    let key = types::DataKey::Position(user.clone(), f.token_id.clone());
+    let ttl = get_persistent_ttl(&f.env, &f.contract_id, &key);
+    assert!(
+        ttl >= constants::TTL_TARGET_PERSISTENT,
+        "Position TTL after deposit should be >= TTL_TARGET_PERSISTENT ({}) but got {ttl}",
+        constants::TTL_TARGET_PERSISTENT
+    );
+}
+
+#[test]
+fn test_ttl_deposit_bumps_user_assets_key() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+    f.client.deposit(&user, &f.token_id, &500);
+
+    let key = types::DataKey::UserAssets(user.clone());
+    let ttl = get_persistent_ttl(&f.env, &f.contract_id, &key);
+    assert!(
+        ttl >= constants::TTL_TARGET_PERSISTENT,
+        "UserAssets TTL after deposit should be >= TTL_TARGET_PERSISTENT ({}) but got {ttl}",
+        constants::TTL_TARGET_PERSISTENT
+    );
+}
+
+#[test]
+fn test_ttl_deposit_bumps_position_index() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+    f.client.deposit(&user, &f.token_id, &500);
+
+    let key = types::DataKey::PositionIndex;
+    let ttl = get_persistent_ttl(&f.env, &f.contract_id, &key);
+    assert!(
+        ttl >= constants::TTL_TARGET_PERSISTENT,
+        "PositionIndex TTL after deposit should be >= TTL_TARGET_PERSISTENT ({}) but got {ttl}",
+        constants::TTL_TARGET_PERSISTENT
+    );
+}
+
+#[test]
+fn test_ttl_set_admin_bumps_instance() {
+    let f = setup_ttl();
+    let new_admin = Address::generate(&f.env);
+    f.client.set_admin(&new_admin);
+
+    let ttl = get_instance_ttl(&f.env, &f.contract_id);
+    assert!(
+        ttl >= constants::TTL_TARGET_INSTANCE,
+        "instance TTL after set_admin should be >= TTL_TARGET_INSTANCE ({}) but got {ttl}",
+        constants::TTL_TARGET_INSTANCE
+    );
+}
+
+#[test]
+fn test_ttl_pause_bumps_instance() {
+    let f = setup_ttl();
+    f.client.pause();
+
+    let ttl = get_instance_ttl(&f.env, &f.contract_id);
+    assert!(
+        ttl >= constants::TTL_TARGET_INSTANCE,
+        "instance TTL after pause should be >= TTL_TARGET_INSTANCE ({}) but got {ttl}",
+        constants::TTL_TARGET_INSTANCE
+    );
+}
+
+#[test]
+fn test_ttl_unpause_bumps_instance() {
+    let f = setup_ttl();
+    f.client.pause();
+    f.client.unpause();
+
+    let ttl = get_instance_ttl(&f.env, &f.contract_id);
+    assert!(
+        ttl >= constants::TTL_TARGET_INSTANCE,
+        "instance TTL after unpause should be >= TTL_TARGET_INSTANCE ({}) but got {ttl}",
+        constants::TTL_TARGET_INSTANCE
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. TTL extension on read when below threshold
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ttl_read_extends_position_when_below_threshold() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+    f.client.deposit(&user, &f.token_id, &500);
+
+    // Advance ledger to drain TTL to just below TTL_THRESHOLD_PERSISTENT.
+    // extend_ttl sets TTL relative to current ledger, so we advance to:
+    // current_seq + TTL_TARGET_PERSISTENT - TTL_THRESHOLD_PERSISTENT + 1
+    let drain_to =
+        100u32 + constants::TTL_TARGET_PERSISTENT - constants::TTL_THRESHOLD_PERSISTENT + 1;
+    f.env.ledger().set_sequence_number(drain_to);
+
+    // This read must trigger an extension
+    let balance = f.client.get_position_balance(&user, &f.token_id);
+    assert_eq!(balance, 500);
+
+    let key = types::DataKey::Position(user.clone(), f.token_id.clone());
+    let ttl_after = get_persistent_ttl(&f.env, &f.contract_id, &key);
+    assert!(
+        ttl_after >= constants::TTL_TARGET_PERSISTENT,
+        "Position TTL should be extended after read below threshold, got {ttl_after}"
+    );
+}
+
+#[test]
+fn test_ttl_read_extends_instance_when_below_threshold() {
+    let f = setup_ttl();
+
+    // Drain instance TTL below TTL_THRESHOLD_INSTANCE
+    let drain_to = 100u32 + constants::TTL_TARGET_INSTANCE - constants::TTL_THRESHOLD_INSTANCE + 1;
+    f.env.ledger().set_sequence_number(drain_to);
+
+    // Any instance read — get_admin — should trigger the bump
+    let admin = f.client.get_admin();
+    assert!(admin.is_some());
+
+    let ttl_after = get_instance_ttl(&f.env, &f.contract_id);
+    assert!(
+        ttl_after >= constants::TTL_TARGET_INSTANCE,
+        "instance TTL should be extended after read below threshold, got {ttl_after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. No premature extension when TTL is above threshold
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ttl_no_extension_when_above_threshold() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+    f.client.deposit(&user, &f.token_id, &500);
+
+    let key = types::DataKey::Position(user.clone(), f.token_id.clone());
+
+    // TTL right after deposit is at target
+    let ttl_before = get_persistent_ttl(&f.env, &f.contract_id, &key);
+    assert!(ttl_before >= constants::TTL_TARGET_PERSISTENT);
+
+    // Advance by a small amount — TTL still well above threshold
+    f.env.ledger().set_sequence_number(110);
+
+    // Read — must NOT increase TTL above where it was before advance
+    let _ = f.client.get_position_balance(&user, &f.token_id);
+    let ttl_after = get_persistent_ttl(&f.env, &f.contract_id, &key);
+
+    // After advancing 10 ledgers the TTL decreases by 10; a no-op extend_ttl
+    // (because we're still above threshold) will leave it at ttl_before - 10.
+    assert!(
+        ttl_after <= ttl_before,
+        "TTL must not increase above pre-read value when already above threshold: before={ttl_before} after={ttl_after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Boundary tests — exactly at threshold and threshold+1
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ttl_boundary_exactly_at_threshold_triggers_extension() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+    f.client.deposit(&user, &f.token_id, &500);
+
+    let key = types::DataKey::Position(user.clone(), f.token_id.clone());
+
+    // Advance ledger so TTL drops to exactly TTL_THRESHOLD_PERSISTENT.
+    // TTL = TTL_TARGET_PERSISTENT - ledgers_advanced
+    // We want TTL = TTL_THRESHOLD_PERSISTENT
+    // => ledgers_advanced = TTL_TARGET_PERSISTENT - TTL_THRESHOLD_PERSISTENT
+    let advance = constants::TTL_TARGET_PERSISTENT - constants::TTL_THRESHOLD_PERSISTENT;
+    f.env.ledger().set_sequence_number(100 + advance);
+
+    // At this point TTL == TTL_THRESHOLD_PERSISTENT — extension must fire
+    let _ = f.client.get_position_balance(&user, &f.token_id);
+    let ttl_after = get_persistent_ttl(&f.env, &f.contract_id, &key);
+    assert!(
+        ttl_after >= constants::TTL_TARGET_PERSISTENT,
+        "extension must fire at exactly threshold: TTL after={ttl_after}"
+    );
+}
+
+#[test]
+fn test_ttl_boundary_one_above_threshold_no_extension() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+    f.client.deposit(&user, &f.token_id, &500);
+
+    let key = types::DataKey::Position(user.clone(), f.token_id.clone());
+
+    // Advance so TTL == TTL_THRESHOLD_PERSISTENT + 1  (one above threshold)
+    let advance = constants::TTL_TARGET_PERSISTENT - constants::TTL_THRESHOLD_PERSISTENT - 1;
+    f.env.ledger().set_sequence_number(100 + advance);
+
+    let ttl_before_read = get_persistent_ttl(&f.env, &f.contract_id, &key);
+
+    let _ = f.client.get_position_balance(&user, &f.token_id);
+    let ttl_after = get_persistent_ttl(&f.env, &f.contract_id, &key);
+
+    // extend_ttl is a no-op when current TTL > threshold, so TTL must not jump
+    assert!(
+        ttl_after <= ttl_before_read,
+        "no extension should fire when TTL is one above threshold: before={ttl_before_read} after={ttl_after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Failed calls must not extend TTL
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ttl_failed_deposit_does_not_extend_ttl() {
+    let f = setup_ttl();
+    let user = Address::generate(&f.env);
+    f.token_admin.mint(&user, &1000);
+
+    // Drain TTL below threshold first
+    let drain_to =
+        100u32 + constants::TTL_TARGET_PERSISTENT - constants::TTL_THRESHOLD_PERSISTENT + 1;
+    f.env.ledger().set_sequence_number(drain_to);
+
+    let key = types::DataKey::Position(user.clone(), f.token_id.clone());
+
+    // Key does not exist yet; check instance TTL before the failed call
+    let instance_ttl_before = get_instance_ttl(&f.env, &f.contract_id);
+
+    // Deposit with zero amount — must fail before writing anything
+    let res = f.client.try_deposit(&user, &f.token_id, &0);
+    assert!(res.is_err());
+
+    // The Position key should not exist at all (deposit never completed)
+    let position_exists = f.env.as_contract(&f.contract_id, || {
+        f.env.storage().persistent().get::<_, i128>(&key).is_some()
+    });
+    assert!(
+        !position_exists,
+        "Position key must not exist after failed deposit"
+    );
+
+    // Instance TTL: the failed call panics before reaching any storage write,
+    // so the instance TTL should not have been extended beyond what it was.
+    // (In the test env, panicking calls roll back all state changes.)
+    let instance_ttl_after = get_instance_ttl(&f.env, &f.contract_id);
+    assert_eq!(
+        instance_ttl_before, instance_ttl_after,
+        "instance TTL must not change after a failed deposit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Constants are distinct (target > threshold)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ttl_constants_target_greater_than_threshold_instance() {
+    const {
+        assert!(
+            constants::TTL_TARGET_INSTANCE > constants::TTL_THRESHOLD_INSTANCE,
+            "TTL_TARGET_INSTANCE must be > TTL_THRESHOLD_INSTANCE",
+        )
+    };
+}
+
+#[test]
+fn test_ttl_constants_target_greater_than_threshold_persistent() {
+    const {
+        assert!(
+            constants::TTL_TARGET_PERSISTENT > constants::TTL_THRESHOLD_PERSISTENT,
+            "TTL_TARGET_PERSISTENT must be > TTL_THRESHOLD_PERSISTENT",
+        )
+    };
+}
+
+#[test]
+fn test_ttl_constants_values_are_nonzero() {
+    const {
+        assert!(constants::TTL_THRESHOLD_INSTANCE > 0);
+        assert!(constants::TTL_TARGET_INSTANCE > 0);
+        assert!(constants::TTL_THRESHOLD_PERSISTENT > 0);
+        assert!(constants::TTL_TARGET_PERSISTENT > 0);
+    };
+}


### PR DESCRIPTION
## Closes
  
  Closes #584
  
  ## Problem
  
  Every value in the collateral-vault was written to persistent storage but
  no TTL was ever extended. Stellar ledger entries have finite lifetimes —
  when a persistent entry's TTL reaches zero it becomes archived and
  inaccessible to normal contract reads until a `RestoreFootprint`
  transaction is submitted. This meant that admin configuration, oracle and
  pool addresses, the supported-asset registry, active user positions, and
  the position index could all silently disappear at different times
  depending on when they were last touched, with no warning to users or
  operators.
  
  ## What was changed
  
  ### `contracts/collateral-vault/src/constants.rs` (new)
  
  Four named TTL constants defined with full rationale and ledger arithmetic
  (1 ledger ≈ 6 seconds on Stellar mainnet):
  
  | Constant | Ledgers | Duration |
  |---|---|---|
  | `TTL_THRESHOLD_INSTANCE` | 100,800 | ~7 days |
  | `TTL_TARGET_INSTANCE` | 432,000 | ~30 days |
  | `TTL_THRESHOLD_PERSISTENT` | 43,200 | ~3 days |
  | `TTL_TARGET_PERSISTENT` | 432,000 | ~30 days |
  
  The file also documents:
  - The complete `DataKey` → storage class classification table.
  - The restoration path for archived entries: operators must submit a
    `RestoreFootprint` transaction referencing the archived ledger key
    before interacting with an archived position. The protocol does not
    perform automatic restoration.
  - Operational responsibility: the contract admin or a keeper bot must
    extend instance and contract-code TTL at least every 14 days.
  
  ### `contracts/collateral-vault/src/storage.rs`
  
  **Storage class migration:**
  
  Configuration keys that are contract-wide and change infrequently were
  moved from `persistent` to `instance` storage, so a single `extend_ttl`
  call covers all of them simultaneously:
  
  | Keys moved to `instance` | Keys kept in `persistent` |
  |---|---|
  | `Admin`, `Paused`, `LendingPool`, `Oracle`, `LiquidationEngine`, `Pool`, `SupportedAssets` | `SupportedAsset(Address)`, `Position(Address, Address)`,
  `PositionIndex`, `UserAssets(Address)` |
  
  **Conditional TTL extension on every access:**
  
  Two internal helpers were added:
  - `bump_instance(env)` — extends instance TTL if below `TTL_THRESHOLD_INSTANCE`.
  - `bump_persistent(env, key)` — extends a specific persistent key's TTL if below `TTL_THRESHOLD_PERSISTENT`.
  
  Both are called after every read and write on their respective storage
  class. Because `extend_ttl` is a no-op when the current TTL already
  exceeds the target, this avoids paying unnecessary resource fees while
  guaranteeing active entries stay alive through normal protocol use.
  
  ### `contracts/collateral-vault/src/tests/test_ttl.rs` (new)
  
  16 tests verifying every acceptance criterion:
  
  - **Write bumps TTL** — `initialize`, `add_supported_asset`, `deposit`
    (checks `Position`, `UserAssets`, and `PositionIndex` keys
    independently), `set_admin`, `pause`, `unpause`.
  - **Read extends below threshold** — advance ledger to drain TTL below
    `TTL_THRESHOLD_PERSISTENT` / `TTL_THRESHOLD_INSTANCE`, call a read
    function, assert TTL is back at target.
  - **No premature extension above threshold** — TTL must not increase
    when it is already healthy.
  - **Boundary conditions** — exactly at threshold (extension fires),
    threshold + 1 (extension does not fire).
  - **Failed call leaves TTL unchanged** — a zero-amount deposit panics
    before any storage write; instance TTL is asserted unchanged.
  - **Compile-time constant sanity** — `const { assert!(..) }` blocks
    verify target > threshold for both storage classes and all values > 0.
  
  ## Test results
  
  86 passed | 0 failed | 0 ignored
  
  All pre-existing tests continue to pass. No public contract interface
  was changed.
