### PR TITLE
feat(shared): implement debt math helpers (accrual, health factor, bo…

### DIFF
--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -8,3 +8,6 @@ pub mod types;
 pub use constant::*;
 pub use errors::*;
 pub use types::*;
+
+#[cfg(test)]
+mod tests;

--- a/contracts/shared/src/tests.rs
+++ b/contracts/shared/src/tests.rs
@@ -1,5 +1,7 @@
 use crate::errors::SharedError;
-use crate::types::{accrue_linear_interest, borrow_limit_from_collateral, ceil_div, health_factor_bps, Debt};
+use crate::types::{
+    accrue_linear_interest, borrow_limit_from_collateral, ceil_div, health_factor_bps, Debt,
+};
 
 #[test]
 fn test_accrue_linear_interest_one_year_eight_percent() {
@@ -45,7 +47,10 @@ fn test_health_factor_zero_debt_is_max() {
 
 #[test]
 fn test_borrow_limit_seventy_percent() {
-    assert_eq!(borrow_limit_from_collateral(10_000_000, 7_000).unwrap(), 7_000_000);
+    assert_eq!(
+        borrow_limit_from_collateral(10_000_000, 7_000).unwrap(),
+        7_000_000
+    );
 }
 
 #[test]

--- a/contracts/shared/src/tests.rs
+++ b/contracts/shared/src/tests.rs
@@ -1,0 +1,58 @@
+use crate::errors::SharedError;
+use crate::types::{accrue_linear_interest, borrow_limit_from_collateral, ceil_div, health_factor_bps, Debt};
+
+#[test]
+fn test_accrue_linear_interest_one_year_eight_percent() {
+    assert_eq!(
+        accrue_linear_interest(1_000_000_000, 800, 31_536_000).unwrap(),
+        80_000_000
+    );
+}
+
+#[test]
+fn test_accrue_linear_interest_zero_elapsed_is_zero() {
+    assert_eq!(accrue_linear_interest(1_000_000_000, 800, 0).unwrap(), 0);
+}
+
+#[test]
+fn test_accrue_linear_interest_rejects_negative_principal() {
+    assert_eq!(
+        accrue_linear_interest(-1, 800, 31_536_000),
+        Err(SharedError::InvalidAmount)
+    );
+}
+
+#[test]
+fn test_debt_total_is_principal_plus_accrued() {
+    let debt = Debt {
+        principal: 1_000_000_000,
+        accrued_interest: 80_000_000,
+        interest_rate_bps: 800,
+        last_accrual_at: 0,
+    };
+    assert_eq!(debt.total().unwrap(), 1_080_000_000);
+}
+
+#[test]
+fn test_health_factor_bps_example_from_arch() {
+    assert_eq!(health_factor_bps(10_000, 7_500, 8_000).unwrap(), 10_666);
+}
+
+#[test]
+fn test_health_factor_zero_debt_is_max() {
+    assert_eq!(health_factor_bps(10_000, 0, 8_000).unwrap(), i128::MAX);
+}
+
+#[test]
+fn test_borrow_limit_seventy_percent() {
+    assert_eq!(borrow_limit_from_collateral(10_000_000, 7_000).unwrap(), 7_000_000);
+}
+
+#[test]
+fn test_ceil_div_rounds_up() {
+    assert_eq!(ceil_div(10, 3).unwrap(), 4);
+    assert_eq!(ceil_div(9, 3).unwrap(), 3);
+    assert_eq!(ceil_div(1, 3).unwrap(), 1);
+    assert_eq!(ceil_div(0, 3).unwrap(), 0);
+    assert_eq!(ceil_div(5, -2).unwrap(), -2);
+}

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::contracttype;
 
+use crate::constant::{BPS_DENOMINATOR, SECONDS_PER_YEAR};
 use crate::errors::SharedError;
 
 #[contracttype]
@@ -21,8 +22,9 @@ pub struct Debt {
 
 impl Debt {
     pub fn total(&self) -> Result<i128, SharedError> {
-        let _ = self;
-        Err(SharedError::NotImplemented)
+        self.principal
+            .checked_add(self.accrued_interest)
+            .ok_or(SharedError::Overflow)
     }
 }
 
@@ -40,8 +42,18 @@ pub fn accrue_linear_interest(
     rate_bps: u32,
     elapsed_seconds: u64,
 ) -> Result<i128, SharedError> {
-    let _ = (principal, rate_bps, elapsed_seconds);
-    Err(SharedError::NotImplemented)
+    if principal < 0 {
+        return Err(SharedError::InvalidAmount);
+    }
+    let annual = principal
+        .checked_mul(rate_bps as i128)
+        .ok_or(SharedError::Overflow)?
+        / BPS_DENOMINATOR;
+    annual
+        .checked_mul(elapsed_seconds as i128)
+        .ok_or(SharedError::Overflow)?
+        .checked_div(SECONDS_PER_YEAR as i128)
+        .ok_or(SharedError::DivisionByZero)
 }
 
 pub fn health_factor_bps(
@@ -49,19 +61,41 @@ pub fn health_factor_bps(
     debt: i128,
     liquidation_threshold_bps: u32,
 ) -> Result<i128, SharedError> {
-    let _ = (collateral_value, debt, liquidation_threshold_bps);
-    Err(SharedError::NotImplemented)
+    if debt == 0 {
+        return Ok(i128::MAX);
+    }
+    if debt < 0 {
+        return Err(SharedError::InvalidAmount);
+    }
+    let numerator = collateral_value
+        .checked_mul(liquidation_threshold_bps as i128)
+        .ok_or(SharedError::Overflow)?;
+    Ok(numerator / debt)
 }
 
 pub fn borrow_limit_from_collateral(
     collateral_value: i128,
     max_ltv_bps: u32,
 ) -> Result<i128, SharedError> {
-    let _ = (collateral_value, max_ltv_bps);
-    Err(SharedError::NotImplemented)
+    if collateral_value < 0 {
+        return Err(SharedError::InvalidAmount);
+    }
+    collateral_value
+        .checked_mul(max_ltv_bps as i128)
+        .ok_or(SharedError::Overflow)?
+        .checked_div(BPS_DENOMINATOR)
+        .ok_or(SharedError::DivisionByZero)
 }
 
 pub fn ceil_div(numerator: i128, denominator: i128) -> Result<i128, SharedError> {
-    let _ = (numerator, denominator);
-    Err(SharedError::NotImplemented)
+    if denominator == 0 {
+        return Err(SharedError::DivisionByZero);
+    }
+    let quotient = numerator / denominator;
+    let remainder = numerator % denominator;
+    if remainder != 0 && ((remainder > 0) == (denominator > 0)) {
+        quotient.checked_add(1).ok_or(SharedError::Overflow)
+    } else {
+        Ok(quotient)
+    }
 }


### PR DESCRIPTION
closes #615 
…rrow limit, ceil div) with tests

# Implement shared debt math helpers

## Summary

Fills in the bodies of the frozen math functions in `contracts/shared` so `vault` and `pool` can call them. No signatures were changed; no borrow, repay, or vault behavior was implemented.

## Changes

- `contracts/shared/src/types.rs` — implemented:
  - `Debt::total` — checked `principal + accrued_interest`, returns `Overflow` on overflow.
  - `accrue_linear_interest` — `principal * rate_bps / 10_000 * elapsed_seconds / 31_536_000` with checked arithmetic (no unwrap), rejects negative principal with `InvalidAmount`.
  - `health_factor_bps` — floor division of `collateral_value * liquidation_threshold_bps / debt`; returns `i128::MAX` when `debt == 0`.
  - `borrow_limit_from_collateral` — floor `collateral_value * max_ltv_bps / 10_000`.
  - `ceil_div` — rounds toward +inf (away from zero) for positive values.
- `contracts/shared/src/lib.rs` — added `#[cfg(test)] mod tests;`.
- `contracts/shared/src/tests.rs` — new file with 8 unit tests covering the above, per the issue's mandatory test list.

## Test results

`cargo test -p shared --all-features`:

```
running 8 tests
test tests::test_accrue_linear_interest_one_year_eight_percent ... ok
test tests::test_accrue_linear_interest_rejects_negative_principal ... ok
test tests::test_accrue_linear_interest_zero_elapsed_is_zero ... ok
test tests::test_borrow_limit_seventy_percent ... ok
test tests::test_ceil_div_rounds_up ... ok
test tests::test_debt_total_is_principal_plus_accrued ... ok
test tests::test_health_factor_bps_example_from_arch ... ok
test tests::test_health_factor_zero_debt_is_max ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Notes

- The crate remains `no_std`.
- One discrepancy in the issue's expected value was resolved: the mandatory accrual test comment stated `interest=8_000_000`, but the required formula produces `80_000_000` for `principal=1_000_000_000, rate=800, elapsed=31_536_000`. The test asserts the formula-correct value `80_000_000`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accurate calculations for debt totals, interest accrual, health factors, collateral-based borrowing limits, and ceiling division.
  * Added validation and overflow handling for edge cases, including zero, negative, rounding, and maximum-value inputs.

* **Tests**
  * Added comprehensive unit tests covering core financial calculations and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->