### PR TITLE
Implement lending-pool admin functions: initialize, set_admin, set_vault, set_oracle, pause_operation, unpause_operation

### DIFF
--- a/contracts/lending-pool/src/admin.rs
+++ b/contracts/lending-pool/src/admin.rs
@@ -1,7 +1,9 @@
 use soroban_sdk::{Address, Env, Symbol};
 
 use crate::errors::PoolError;
-use crate::types::PauseFlag;
+use crate::events;
+use crate::storage::{self, get_pause_mask, set_pause_mask};
+use crate::types::{pause_flag_symbol, PauseFlag};
 
 pub fn initialize(
     env: Env,
@@ -11,31 +13,119 @@ pub fn initialize(
     borrow_asset: Address,
     interest_rate_bps: u32,
 ) -> Result<(), PoolError> {
-    let _ = (env, admin, vault, oracle, borrow_asset, interest_rate_bps);
-    Err(PoolError::NotImplemented)
+    if storage::has_admin(&env) {
+        return Err(PoolError::AlreadyInitialized);
+    }
+
+    admin.require_auth();
+
+    if vault == oracle {
+        return Err(PoolError::InvalidAddress);
+    }
+
+    if interest_rate_bps == 0 {
+        return Err(PoolError::InvalidRate);
+    }
+
+    storage::set_admin(&env, &admin);
+    storage::set_vault(&env, &vault);
+    storage::set_oracle(&env, &oracle);
+    storage::set_borrow_asset(&env, &borrow_asset);
+    storage::set_interest_rate_bps(&env, interest_rate_bps);
+    storage::set_pause_mask(&env, 0);
+
+    events::Initialized {
+        admin,
+        vault,
+        oracle,
+        borrow_asset,
+        interest_rate_bps,
+    }
+    .publish(&env);
+
+    Ok(())
 }
 
 pub fn set_admin(env: Env, new_admin: Address) -> Result<(), PoolError> {
-    let _ = (env, new_admin);
-    Err(PoolError::NotImplemented)
+    let current_admin = storage::get_admin(&env).ok_or(PoolError::NotInitialized)?;
+    current_admin.require_auth();
+
+    if current_admin == new_admin {
+        return Err(PoolError::AlreadyAdmin);
+    }
+
+    let new_admin_clone = new_admin.clone();
+    events::AdminChanged {
+        old_admin: current_admin,
+        new_admin: new_admin_clone,
+    }
+    .publish(&env);
+
+    storage::set_admin(&env, &new_admin);
+    Ok(())
 }
 
 pub fn set_vault(env: Env, vault: Address) -> Result<(), PoolError> {
-    let _ = (env, vault);
-    Err(PoolError::NotImplemented)
+    let admin = storage::get_admin(&env).ok_or(PoolError::NotInitialized)?;
+    admin.require_auth();
+
+    storage::set_vault(&env, &vault);
+    Ok(())
 }
 
 pub fn set_oracle(env: Env, oracle: Address) -> Result<(), PoolError> {
-    let _ = (env, oracle);
-    Err(PoolError::NotImplemented)
+    let admin = storage::get_admin(&env).ok_or(PoolError::NotInitialized)?;
+    admin.require_auth();
+
+    storage::set_oracle(&env, &oracle);
+    Ok(())
 }
 
 pub fn pause_operation(env: Env, operation: PauseFlag, reason: Symbol) -> Result<(), PoolError> {
-    let _ = (env, operation, reason);
-    Err(PoolError::NotImplemented)
+    let admin = storage::get_admin(&env).ok_or(PoolError::NotInitialized)?;
+    admin.require_auth();
+
+    let current_mask = get_pause_mask(&env);
+    let flag_bit = operation.bit();
+
+    if current_mask & flag_bit != 0 {
+        return Err(PoolError::AlreadyPaused);
+    }
+
+    let new_mask = current_mask | flag_bit;
+    set_pause_mask(&env, new_mask);
+
+    let operation_symbol = pause_flag_symbol(&env, &operation);
+    events::OperationPaused {
+        by: admin,
+        operation: operation_symbol,
+        reason,
+    }
+    .publish(&env);
+
+    Ok(())
 }
 
 pub fn unpause_operation(env: Env, operation: PauseFlag) -> Result<(), PoolError> {
-    let _ = (env, operation);
-    Err(PoolError::NotImplemented)
+    let admin = storage::get_admin(&env).ok_or(PoolError::NotInitialized)?;
+    admin.require_auth();
+
+    let current_mask = get_pause_mask(&env);
+    let flag_bit = operation.bit();
+
+    if current_mask & flag_bit == 0 {
+        return Err(PoolError::NotPaused);
+    }
+
+    let new_mask = current_mask & !flag_bit;
+    set_pause_mask(&env, new_mask);
+
+    let operation_symbol = pause_flag_symbol(&env, &operation);
+    events::OperationUnpaused {
+        by: admin,
+        operation: operation_symbol,
+    }
+    .publish(&env);
+
+    Ok(())
 }

--- a/contracts/lending-pool/src/events.rs
+++ b/contracts/lending-pool/src/events.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{contractevent, Address};
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Initialized {
+    #[topic]
     pub admin: Address,
     pub vault: Address,
     pub oracle: Address,
@@ -14,14 +15,18 @@ pub struct Initialized {
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AdminChanged {
+    #[topic]
     pub old_admin: Address,
+    #[topic]
     pub new_admin: Address,
 }
 
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct OperationPaused {
+    #[topic]
     pub by: Address,
+    #[topic]
     pub operation: soroban_sdk::Symbol,
     pub reason: soroban_sdk::Symbol,
 }
@@ -29,7 +34,9 @@ pub struct OperationPaused {
 #[contractevent]
 #[derive(Clone, Debug, PartialEq)]
 pub struct OperationUnpaused {
+    #[topic]
     pub by: Address,
+    #[topic]
     pub operation: soroban_sdk::Symbol,
 }
 

--- a/contracts/lending-pool/src/tests/mod.rs
+++ b/contracts/lending-pool/src/tests/mod.rs
@@ -1,1 +1,3 @@
+mod test_admin;
+mod test_pause;
 mod test_supply;

--- a/contracts/lending-pool/src/tests/test_admin.rs
+++ b/contracts/lending-pool/src/tests/test_admin.rs
@@ -1,0 +1,133 @@
+#![cfg(test)]
+
+use super::super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, Env};
+
+fn setup_env() -> (
+    Env,
+    PoolContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+    token::Client<'static>,
+    token::StellarAssetClient<'static>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PoolContract, ());
+    let client = PoolContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let vault = Address::generate(&env);
+    let _oracle = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+    let token_contract_id = token_contract.address();
+    let token_client = token::Client::new(&env, &token_contract_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+
+    (
+        env,
+        client,
+        admin,
+        user,
+        vault,
+        token_contract_id,
+        token_client,
+        token_admin_client,
+    )
+}
+
+#[test]
+fn test_initialize_success() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &500);
+
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+    assert_eq!(client.get_vault(), Some(vault.clone()));
+    assert_eq!(client.get_oracle(), Some(oracle.clone()));
+    assert_eq!(client.get_borrow_asset(), Some(token_id.clone()));
+    assert_eq!(client.get_interest_rate_bps(), 500);
+}
+
+#[test]
+fn test_initialize_duplicate_fails() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &500);
+
+    let res = client.try_initialize(&admin, &vault, &oracle, &token_id, &500);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_initialize_vault_equals_oracle_fails() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+
+    let res = client.try_initialize(&admin, &vault, &vault, &token_id, &500);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_initialize_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(PoolContract, ());
+    let client = PoolContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let vault = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+    let token_contract_id = token_contract.address();
+
+    // No mock_all_auths - initialize should fail auth check
+    let res = client.try_initialize(&admin, &vault, &oracle, &token_contract_id, &500);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_set_admin_success() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &500);
+    client.set_admin(&new_admin);
+
+    assert_eq!(client.get_admin(), Some(new_admin));
+}
+
+#[test]
+fn test_set_admin_same_address_fails() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &500);
+
+    let res = client.try_set_admin(&admin);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_getters_match_initialize_args() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+    let interest_rate_bps = 500;
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &interest_rate_bps);
+
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+    assert_eq!(client.get_vault(), Some(vault.clone()));
+    assert_eq!(client.get_oracle(), Some(oracle.clone()));
+    assert_eq!(client.get_borrow_asset(), Some(token_id.clone()));
+    assert_eq!(client.get_interest_rate_bps(), interest_rate_bps);
+}

--- a/contracts/lending-pool/src/tests/test_admin.rs
+++ b/contracts/lending-pool/src/tests/test_admin.rs
@@ -70,7 +70,7 @@ fn test_initialize_duplicate_fails() {
 
 #[test]
 fn test_initialize_vault_equals_oracle_fails() {
-    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let (_env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
 
     let res = client.try_initialize(&admin, &vault, &vault, &token_id, &500);
     assert!(res.is_err());

--- a/contracts/lending-pool/src/tests/test_pause.rs
+++ b/contracts/lending-pool/src/tests/test_pause.rs
@@ -1,0 +1,74 @@
+#![cfg(test)]
+
+use super::super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, Env, Symbol};
+
+fn setup_env() -> (
+    Env,
+    PoolContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+    token::Client<'static>,
+    token::StellarAssetClient<'static>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PoolContract, ());
+    let client = PoolContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let vault = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+    let token_contract_id = token_contract.address();
+    let token_client = token::Client::new(&env, &token_contract_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+
+    client.initialize(&admin, &vault, &oracle, &token_contract_id, &500);
+
+    (
+        env,
+        client,
+        admin,
+        user,
+        vault,
+        token_contract_id,
+        token_client,
+        token_admin_client,
+    )
+}
+
+#[test]
+fn test_pause_and_unpause_borrow() {
+    let (env, client, _admin, _user, _vault, _token_id, _token_client, _token_admin) = setup_env();
+
+    client.pause_operation(&PauseFlag::Borrow, &Symbol::new(&env, "test"));
+
+    let res = client.try_unpause_operation(&PauseFlag::Borrow);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_double_pause_fails() {
+    let (env, client, _admin, _user, _vault, _token_id, _token_client, _token_admin) = setup_env();
+
+    client.pause_operation(&PauseFlag::Borrow, &Symbol::new(&env, "test"));
+
+    let res = client.try_pause_operation(&PauseFlag::Borrow, &Symbol::new(&env, "test"));
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_unpause_when_not_paused_fails() {
+    let (_env, client, _admin, _user, _vault, _token_id, _token_client, _token_admin) = setup_env();
+
+    let res = client.try_unpause_operation(&PauseFlag::Borrow);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## **User description**
closes #618

**Implemented admin functions in [contracts/lending-pool/src/admin.rs](cci:7://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/admin.rs:0:0-0:0):**
- [initialize](cci:1://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/admin.rs:7:0-46:1): Rejects if already initialized, requires admin auth, rejects vault == oracle, rejects interest_rate_bps == 0 with InvalidRate, stores admin/vault/oracle/borrow_asset/rate, sets pause mask to 0, emits Initialized event
- [set_admin](cci:1://file:///home/lynndabel/Alien-Protocol/contracts/collateral-vault/src/admin.rs:3:0-20:1): Requires admin auth, rejects same address with AlreadyAdmin, emits AdminChanged event
- [set_vault](cci:1://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/admin.rs:67:0-73:1): Requires admin auth
- [set_oracle](cci:1://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/admin.rs:75:0-81:1): Requires admin auth  
- [pause_operation](cci:1://file:///home/lynndabel/Alien-Protocol/contracts/collateral-vault/src/admin.rs:77:0-95:1): Requires admin auth, uses bitmask with pause_flag_symbol, rejects AlreadyPaused, emits OperationPaused event
- [unpause_operation](cci:1://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/admin.rs:107:0-129:1): Requires admin auth, uses bitmask, rejects NotPaused, emits OperationUnpaused event

**Updated [contracts/lending-pool/src/events.rs](cci:7://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/events.rs:0:0-0:0):**
- Added `#[topic]` attributes to event fields for proper event publishing

**Created test files:**
- [contracts/lending-pool/src/tests/test_admin.rs](cci:7://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/tests/test_admin.rs:0:0-0:0) with 7 required tests
- [contracts/lending-pool/src/tests/test_pause.rs](cci:7://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/tests/test_pause.rs:0:0-0:0) with 3 required tests
- Registered both in [contracts/lending-pool/src/tests/mod.rs](cci:7://file:///home/lynndabel/Alien-Protocol/contracts/lending-pool/src/tests/mod.rs:0:0-0:0)

**Verification:**
- ✅ `cargo test -p lending-pool --all-features` - 17 tests passed
- ✅ `cargo build -p lending-pool --target wasm32v1-none --release` - succeeded

All acceptance criteria met:
- Double initialize fails with AlreadyInitialized
- Getters match initialize arguments
- Pause/unpause works per flag
- All tests pass
- WASM build succeeds


___

## **CodeAnt-AI Description**
Add lending-pool setup and administration controls

### What Changed
- Lending pools can now be initialized with an admin, vault, oracle, borrowing asset, and nonzero interest rate.
- Administrators can transfer control, update the vault or oracle, and retrieve the saved pool settings.
- Administrators can pause and resume individual operations, with duplicate or invalid state changes rejected.
- Initialization, admin changes, and pause changes now publish searchable events.
- Added coverage for initialization validation, admin changes, and pause/resume behavior.

### Impact
`✅ Configurable lending-pool administration`
`✅ Prevented invalid pool initialization`
`✅ Controlled pausing of lending operations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lending pool initialization with configuration validation and admin authorization.
  * Added administrator, vault, and oracle address management.
  * Added pause and unpause controls for lending operations.
  * Added event tracking for initialization, administrator changes, and operation state changes.

* **Bug Fixes**
  * Prevented duplicate initialization and invalid administrator changes.
  * Prevented repeated pause or unpause actions.

* **Tests**
  * Added coverage for administration, initialization, authorization, and pause controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->