### PR TITLE
Implement permissionless liquidate/is_liquidatable with seize, bonus,…

### DIFF
--- a/contracts/liquidation-engine/src/liquidate.rs
+++ b/contracts/liquidation-engine/src/liquidate.rs
@@ -1,11 +1,12 @@
-use soroban_sdk::{Address, Env, IntoVal};
+use soroban_sdk::{token, Address, Env};
 
 use crate::errors::EngineError;
+use crate::events;
 use crate::storage;
 use crate::types::LiquidationResult;
 use shared::{
-    ceil_div, CLOSE_FACTOR_BPS, HEALTHY_HF_BPS, LIQUIDATION_BONUS_BPS, MIN_REMAINING_DEBT,
-    TARGET_HF_BPS,
+    ceil_div, CollateralAsset, CLOSE_FACTOR_BPS, HEALTHY_HF_BPS, LIQUIDATION_BONUS_BPS,
+    MIN_REMAINING_DEBT, PROTOCOL_QUOTE_PRECISION, TARGET_HF_BPS,
 };
 
 #[soroban_sdk::contractclient(name = "VaultClient")]
@@ -20,6 +21,9 @@ pub trait Vault {
     );
     fn get_health_factor(env: Env, user: Address) -> i128;
     fn get_collateral_value(env: Env, user: Address) -> i128;
+    fn get_position(env: Env, user: Address) -> shared::Position;
+    fn get_asset_config(env: Env, asset: Address) -> shared::AssetConfig;
+    fn get_liquidation_engine(env: Env) -> Option<Address>;
 }
 
 #[soroban_sdk::contractclient(name = "PoolClient")]
@@ -28,37 +32,61 @@ pub trait Pool {
     fn get_user_debt(env: Env, user: Address) -> i128;
     fn is_liquidatable(env: Env, user: Address) -> bool;
     fn repay_for(env: Env, payer: Address, user: Address, asset: Address, amount: i128);
+    fn get_borrow_asset(env: Env) -> Option<Address>;
 }
 
-/// Helper struct to access vault methods not in the Vault trait
-struct VaultHelper {
-    addr: Address,
+/// Oracle client for the liquidation engine.
+///
+/// Declared locally (rather than reused from the vault or pool crates) because
+/// it must match `oracle-adapter`'s three-field `PriceData` (price, timestamp,
+/// write_timestamp), not the vault's two-field `PriceData`.
+#[soroban_sdk::contractclient(name = "OracleClient")]
+#[allow(dead_code)]
+pub trait Oracle {
+    fn get_price(env: Env, asset: Address) -> Option<shared::types::PriceData>;
+    fn get_price_or_fail(env: Env, asset: Address) -> shared::types::PriceData;
 }
 
-impl VaultHelper {
-    fn new(addr: Address) -> Self {
-        Self { addr }
-    }
+/// Converts a quote-unit value (`PROTOCOL_QUOTE_PRECISION`-scaled) into base
+/// token units of an asset, given its decimals and oracle price. Rounds up so
+/// the protocol never under-seizes.
+fn value_to_token_amount(
+    value: i128,
+    price: i128,
+    token_decimals: u32,
+    oracle_price_decimals: u32,
+) -> Result<i128, EngineError> {
+    let exponent = token_decimals
+        .checked_add(oracle_price_decimals)
+        .ok_or(EngineError::Overflow)?;
+    let scale = 10i128.checked_pow(exponent).ok_or(EngineError::Overflow)?;
+    let numerator = value.checked_mul(scale).ok_or(EngineError::Overflow)?;
+    let denominator = PROTOCOL_QUOTE_PRECISION
+        .checked_mul(price)
+        .ok_or(EngineError::Overflow)?;
+    ceil_div(numerator, denominator).map_err(|_| EngineError::Overflow)
+}
 
-    fn get_position(&self, env: &Env, user: &Address) -> Result<shared::Position, EngineError> {
-        env.invoke_contract(
-            &self.addr,
-            &soroban_sdk::Symbol::new(env, "get_position"),
-            soroban_sdk::vec![env, user.into_val(env)],
-        )
-    }
-
-    fn get_asset_config(
-        &self,
-        env: &Env,
-        asset: &Address,
-    ) -> Result<shared::AssetConfig, EngineError> {
-        env.invoke_contract(
-            &self.addr,
-            &soroban_sdk::Symbol::new(env, "get_asset_config"),
-            soroban_sdk::vec![env, asset.into_val(env)],
-        )
-    }
+/// Converts base token units of an asset back into a quote-unit value, given
+/// its decimals and oracle price. Rounds down (floor) so that when a full
+/// collateral balance is seized, the value credited toward the seizure target
+/// never exceeds what was actually taken.
+fn token_amount_to_value(
+    amount: i128,
+    price: i128,
+    token_decimals: u32,
+    oracle_price_decimals: u32,
+) -> Result<i128, EngineError> {
+    let exponent = token_decimals
+        .checked_add(oracle_price_decimals)
+        .ok_or(EngineError::Overflow)?;
+    let scale = 10i128.checked_pow(exponent).ok_or(EngineError::Overflow)?;
+    let numerator = amount
+        .checked_mul(PROTOCOL_QUOTE_PRECISION)
+        .ok_or(EngineError::Overflow)?
+        .checked_mul(price)
+        .ok_or(EngineError::Overflow)?;
+    numerator.checked_div(scale).ok_or(EngineError::Overflow)
 }
 
 pub fn liquidate(
@@ -67,13 +95,153 @@ pub fn liquidate(
     user: Address,
     max_repay_amount: i128,
 ) -> Result<LiquidationResult, EngineError> {
-    let _ = (env, liquidator, user, max_repay_amount);
-    Err(EngineError::NotImplemented)
+    liquidator.require_auth();
+
+    if liquidator == user {
+        return Err(EngineError::Unauthorized);
+    }
+
+    if max_repay_amount <= 0 {
+        return Err(EngineError::InvalidAmount);
+    }
+
+    let vault_addr = storage::get_vault(&env).ok_or(EngineError::NotInitialized)?;
+    let pool_addr = storage::get_pool(&env).ok_or(EngineError::NotInitialized)?;
+    let oracle_addr = storage::get_oracle(&env).ok_or(EngineError::NotInitialized)?;
+
+    let vault = VaultClient::new(&env, &vault_addr);
+    let pool = PoolClient::new(&env, &pool_addr);
+    let oracle = OracleClient::new(&env, &oracle_addr);
+
+    let engine_address = env.current_contract_address();
+
+    let registered_engine = vault
+        .get_liquidation_engine()
+        .ok_or(EngineError::Unauthorized)?;
+    if registered_engine != engine_address {
+        return Err(EngineError::Unauthorized);
+    }
+
+    if !is_liquidatable(env.clone(), user.clone())? {
+        return Err(EngineError::NotLiquidatable);
+    }
+
+    let max_partial_repay = calculate_partial_repayment(env.clone(), user.clone())?;
+    let repay = max_repay_amount.min(max_partial_repay);
+
+    let borrow_asset = pool.get_borrow_asset().ok_or(EngineError::NotInitialized)?;
+
+    // Pull the repayment from the liquidator into the engine, then forward it
+    // to the pool on the engine's own behalf.
+    token::Client::new(&env, &borrow_asset).transfer(&liquidator, &engine_address, &repay);
+    pool.repay_for(&engine_address, &user, &borrow_asset, &repay);
+
+    let bonus = calculate_bonus(env.clone(), repay)?;
+    let seized_value = repay.checked_add(bonus).ok_or(EngineError::Overflow)?;
+    let mut remaining_value = seized_value;
+
+    // Seize collateral starting from the user's largest-balance asset (ties
+    // broken by order in `get_position`), moving to the next asset whenever
+    // one balance is insufficient to cover the remaining seized value.
+    let position = vault.get_position(&user);
+    let mut collateral = position.collateral.clone();
+    let len = collateral.len();
+
+    for _ in 0..len {
+        if remaining_value <= 0 {
+            break;
+        }
+
+        let mut best_idx: Option<u32> = None;
+        let mut best_amount: i128 = 0;
+        for i in 0..len {
+            let candidate = collateral.get_unchecked(i);
+            if candidate.amount > best_amount {
+                best_amount = candidate.amount;
+                best_idx = Some(i);
+            }
+        }
+
+        let idx = best_idx.ok_or(EngineError::InvalidAmount)?;
+        let candidate = collateral.get_unchecked(idx);
+        let asset = candidate.asset.clone();
+        let balance = candidate.amount;
+
+        let asset_config = vault.get_asset_config(&asset);
+        let price_data = oracle.get_price_or_fail(&asset);
+
+        let token_amount_needed = value_to_token_amount(
+            remaining_value,
+            price_data.price,
+            asset_config.token_decimals,
+            asset_config.oracle_price_decimals,
+        )?;
+
+        let seize_amount = if balance >= token_amount_needed {
+            remaining_value = 0;
+            token_amount_needed
+        } else {
+            let value_covered = token_amount_to_value(
+                balance,
+                price_data.price,
+                asset_config.token_decimals,
+                asset_config.oracle_price_decimals,
+            )?;
+            remaining_value = remaining_value
+                .checked_sub(value_covered)
+                .ok_or(EngineError::Overflow)?;
+            balance
+        };
+
+        // Mark this asset processed so it is not selected again.
+        collateral.set(
+            idx,
+            CollateralAsset {
+                asset: asset.clone(),
+                amount: 0,
+            },
+        );
+
+        if seize_amount > 0 {
+            vault.seize_collateral(&engine_address, &user, &asset, &seize_amount);
+            token::Client::new(&env, &asset).transfer(&engine_address, &liquidator, &seize_amount);
+        }
+    }
+
+    if remaining_value > 0 {
+        return Err(EngineError::InvalidAmount);
+    }
+
+    events::Liquidated {
+        user: user.clone(),
+        liquidator: liquidator.clone(),
+        repaid: repay,
+        seized: seized_value,
+        bonus,
+    }
+    .publish(&env);
+
+    Ok(LiquidationResult {
+        user,
+        repaid: repay,
+        seized: seized_value,
+        bonus,
+    })
 }
 
 pub fn is_liquidatable(env: Env, user: Address) -> Result<bool, EngineError> {
-    let _ = (env, user);
-    Err(EngineError::NotImplemented)
+    let vault_addr = storage::get_vault(&env).ok_or(EngineError::NotInitialized)?;
+    let pool_addr = storage::get_pool(&env).ok_or(EngineError::NotInitialized)?;
+
+    let vault = VaultClient::new(&env, &vault_addr);
+    let pool = PoolClient::new(&env, &pool_addr);
+
+    let debt = pool.get_user_debt(&user);
+    if debt == 0 {
+        return Ok(false);
+    }
+
+    Ok(vault.get_health_factor(&user) < HEALTHY_HF_BPS)
 }
 
 pub fn calculate_bonus(env: Env, repaid_amount: i128) -> Result<i128, EngineError> {
@@ -99,7 +267,6 @@ pub fn calculate_partial_repayment(env: Env, user: Address) -> Result<i128, Engi
 
     let vault = VaultClient::new(&env, &vault_addr);
     let pool = PoolClient::new(&env, &pool_addr);
-    let vault_helper = VaultHelper::new(vault_addr);
 
     // Load accrued debt via pool.get_user_debt
     let debt = pool.get_user_debt(&user);
@@ -119,14 +286,14 @@ pub fn calculate_partial_repayment(env: Env, user: Address) -> Result<i128, Engi
     }
 
     // Get position to determine liquidation threshold
-    let position = vault_helper.get_position(&env, &user)?;
+    let position = vault.get_position(&user);
 
     // Recover liquidation threshold as the minimum LT among non-zero assets.
     // Iterate through collateral assets and find the minimum liquidation_threshold_bps.
     let mut min_lt_bps: i128 = i128::MAX;
     for collateral_asset in position.collateral.iter() {
         if collateral_asset.amount > 0 {
-            let asset_config = vault_helper.get_asset_config(&env, &collateral_asset.asset)?;
+            let asset_config = vault.get_asset_config(&collateral_asset.asset);
             let lt_bps = asset_config.liquidation_threshold_bps as i128;
             if lt_bps < min_lt_bps {
                 min_lt_bps = lt_bps;

--- a/contracts/liquidation-engine/src/tests/mod.rs
+++ b/contracts/liquidation-engine/src/tests/mod.rs
@@ -1,1 +1,2 @@
+mod test_liquidate;
 mod test_math;

--- a/contracts/liquidation-engine/src/tests/test_liquidate.rs
+++ b/contracts/liquidation-engine/src/tests/test_liquidate.rs
@@ -1,0 +1,492 @@
+#![cfg(test)]
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+
+use super::super::*;
+use crate::errors::EngineError;
+
+// ---------------------------------------------------------------------------
+// Minimal mock Vault / Pool / Oracle contracts.
+//
+// The production `collateral-vault` and `lending-pool` contracts have
+// dependent logic (debt accrual, `repay_for`) that is not implemented yet in
+// this snapshot of the repo, so the liquidation-engine's own test suite
+// exercises `liquidate.rs` against small, directly-controllable stand-ins
+// that expose the same function names/signatures the engine's `VaultClient`,
+// `PoolClient`, and `OracleClient` invoke.
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+enum VaultKey {
+    Engine,
+    Position(Address),
+    AssetConfig(Address),
+    HealthFactor(Address),
+    CollateralValue(Address),
+}
+
+#[contract]
+struct MockVaultContract;
+
+#[contractimpl]
+impl MockVaultContract {
+    pub fn set_liquidation_engine(env: Env, engine: Address) {
+        env.storage().persistent().set(&VaultKey::Engine, &engine);
+    }
+
+    pub fn set_position(env: Env, position: shared::Position) {
+        env.storage()
+            .persistent()
+            .set(&VaultKey::Position(position.user.clone()), &position);
+    }
+
+    pub fn set_asset_config(env: Env, asset: Address, config: shared::AssetConfig) {
+        env.storage()
+            .persistent()
+            .set(&VaultKey::AssetConfig(asset), &config);
+    }
+
+    pub fn set_health_factor(env: Env, user: Address, hf: i128) {
+        env.storage()
+            .persistent()
+            .set(&VaultKey::HealthFactor(user), &hf);
+    }
+
+    pub fn set_collateral_value(env: Env, user: Address, value: i128) {
+        env.storage()
+            .persistent()
+            .set(&VaultKey::CollateralValue(user), &value);
+    }
+
+    pub fn get_liquidation_engine(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&VaultKey::Engine)
+    }
+
+    pub fn get_position(env: Env, user: Address) -> shared::Position {
+        env.storage()
+            .persistent()
+            .get(&VaultKey::Position(user))
+            .expect("no position")
+    }
+
+    pub fn get_asset_config(env: Env, asset: Address) -> shared::AssetConfig {
+        env.storage()
+            .persistent()
+            .get(&VaultKey::AssetConfig(asset))
+            .expect("no asset config")
+    }
+
+    pub fn get_health_factor(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&VaultKey::HealthFactor(user))
+            .unwrap_or(i128::MAX)
+    }
+
+    pub fn get_collateral_value(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&VaultKey::CollateralValue(user))
+            .unwrap_or(0)
+    }
+
+    pub fn seize_collateral(
+        env: Env,
+        liquidation_engine: Address,
+        _user: Address,
+        asset: Address,
+        amount: i128,
+    ) {
+        liquidation_engine.require_auth();
+        token::Client::new(&env, &asset).transfer(
+            &env.current_contract_address(),
+            &liquidation_engine,
+            &amount,
+        );
+    }
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum PoolKey {
+    BorrowAsset,
+    Debt(Address),
+    LastRepay,
+}
+
+#[contract]
+struct MockPoolContract;
+
+#[contractimpl]
+impl MockPoolContract {
+    pub fn set_borrow_asset(env: Env, asset: Address) {
+        env.storage()
+            .persistent()
+            .set(&PoolKey::BorrowAsset, &asset);
+    }
+
+    pub fn set_debt(env: Env, user: Address, debt: i128) {
+        env.storage().persistent().set(&PoolKey::Debt(user), &debt);
+    }
+
+    pub fn get_borrow_asset(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&PoolKey::BorrowAsset)
+    }
+
+    pub fn get_user_debt(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&PoolKey::Debt(user))
+            .unwrap_or(0)
+    }
+
+    pub fn is_liquidatable(_env: Env, _user: Address) -> bool {
+        false
+    }
+
+    pub fn repay_for(env: Env, payer: Address, user: Address, asset: Address, amount: i128) {
+        payer.require_auth();
+
+        let pool_addr = env.current_contract_address();
+        token::Client::new(&env, &asset).transfer(&payer, &pool_addr, &amount);
+
+        let current_debt: i128 = env
+            .storage()
+            .persistent()
+            .get(&PoolKey::Debt(user.clone()))
+            .unwrap_or(0);
+        let new_debt = (current_debt - amount).max(0);
+        env.storage()
+            .persistent()
+            .set(&PoolKey::Debt(user), &new_debt);
+
+        env.storage()
+            .persistent()
+            .set(&PoolKey::LastRepay, &(payer, amount));
+    }
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum OracleKey {
+    Price(Address),
+}
+
+#[contract]
+struct MockOracleContract;
+
+#[contractimpl]
+impl MockOracleContract {
+    pub fn set_price(env: Env, asset: Address, price: shared::types::PriceData) {
+        env.storage()
+            .persistent()
+            .set(&OracleKey::Price(asset), &price);
+    }
+
+    pub fn get_price(env: Env, asset: Address) -> Option<shared::types::PriceData> {
+        env.storage().persistent().get(&OracleKey::Price(asset))
+    }
+
+    pub fn get_price_or_fail(env: Env, asset: Address) -> shared::types::PriceData {
+        env.storage()
+            .persistent()
+            .get(&OracleKey::Price(asset))
+            .expect("no price")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: a scaled-up version of the numeric fixture used in test_math.rs
+// (collateral = 10_000, debt = 8_100, lt = 8_000 bps), multiplied by 1e6 so
+// remaining debt stays well above `MIN_REMAINING_DEBT`
+// (`PROTOCOL_QUOTE_PRECISION` = 10_000_000) and the dust fallback doesn't
+// kick in. Collateral price is set to exactly `PROTOCOL_QUOTE_PRECISION`
+// with matching 7-decimal token/oracle precision, so quote-unit values and
+// collateral token units are 1:1 and easy to assert on.
+// ---------------------------------------------------------------------------
+const COLLATERAL_VALUE: i128 = 10_000_000_000;
+const DEBT: i128 = 8_100_000_000;
+const LT_BPS: u32 = 8_000;
+const HEALTH_FACTOR_UNHEALTHY: i128 = 9_876; // floor(10_000_000_000 * 8_000 / 8_100_000_000)
+const HEALTH_FACTOR_HEALTHY: i128 = 10_500;
+// Exact result of `calculate_partial_repayment`'s ceil_div-based formula for
+// this fixture; ceil_div does not scale linearly with the underlying
+// fixture, so this is the precise value rather than a naive x1e6 scale-up of
+// test_math.rs's 3_856 fixture result.
+const EXPECTED_PARTIAL_REPAY: i128 = 3_855_932_204;
+const COLLATERAL_BALANCE: i128 = 6_000_000_000;
+
+fn expected_bonus(repay: i128) -> i128 {
+    shared::ceil_div(repay * 800, 10_000).unwrap()
+}
+
+#[allow(dead_code)]
+struct Env_ {
+    env: Env,
+    engine: LiquidationContractClient<'static>,
+    engine_addr: Address,
+    vault: MockVaultContractClient<'static>,
+    vault_addr: Address,
+    pool: MockPoolContractClient<'static>,
+    pool_addr: Address,
+    oracle: MockOracleContractClient<'static>,
+    oracle_addr: Address,
+    admin: Address,
+    liquidator: Address,
+    user: Address,
+    borrow_asset: Address,
+    borrow_token: token::Client<'static>,
+    collateral_asset: Address,
+    collateral_token: token::Client<'static>,
+}
+
+fn setup() -> Env_ {
+    let env = Env::default();
+    // The engine authorizes nested contract-to-contract calls it initiates
+    // (e.g. the pool pulling repayment tokens from the engine's own balance),
+    // which are not root-invocation arguments, so plain `mock_all_auths`
+    // isn't enough here.
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let engine_id = env.register(LiquidationContract, ());
+    let engine = LiquidationContractClient::new(&env, &engine_id);
+
+    let vault_id = env.register(MockVaultContract, ());
+    let vault = MockVaultContractClient::new(&env, &vault_id);
+
+    let pool_id = env.register(MockPoolContract, ());
+    let pool = MockPoolContractClient::new(&env, &pool_id);
+
+    let oracle_id = env.register(MockOracleContract, ());
+    let oracle = MockOracleContractClient::new(&env, &oracle_id);
+
+    let admin = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    env.as_contract(&engine_id, || {
+        crate::storage::set_admin(&env, &admin);
+        crate::storage::set_vault(&env, &vault_id);
+        crate::storage::set_pool(&env, &pool_id);
+        crate::storage::set_oracle(&env, &oracle_id);
+    });
+
+    vault.set_liquidation_engine(&engine_id);
+
+    let borrow_token_admin = Address::generate(&env);
+    let borrow_asset = env
+        .register_stellar_asset_contract_v2(borrow_token_admin)
+        .address();
+    let borrow_token = token::Client::new(&env, &borrow_asset);
+    let borrow_token_admin_client = token::StellarAssetClient::new(&env, &borrow_asset);
+    borrow_token_admin_client.mint(&liquidator, &1_000_000_000_000);
+    pool.set_borrow_asset(&borrow_asset);
+
+    let collateral_token_admin = Address::generate(&env);
+    let collateral_asset = env
+        .register_stellar_asset_contract_v2(collateral_token_admin)
+        .address();
+    let collateral_token = token::Client::new(&env, &collateral_asset);
+    let collateral_token_admin_client = token::StellarAssetClient::new(&env, &collateral_asset);
+    collateral_token_admin_client.mint(&vault_id, &COLLATERAL_BALANCE);
+
+    vault.set_asset_config(
+        &collateral_asset,
+        &shared::AssetConfig {
+            token_decimals: 7,
+            oracle_price_decimals: 7,
+            max_ltv_bps: 7_000,
+            liquidation_threshold_bps: LT_BPS,
+        },
+    );
+    oracle.set_price(
+        &collateral_asset,
+        &shared::types::PriceData {
+            price: shared::PROTOCOL_QUOTE_PRECISION,
+            timestamp: 1,
+            write_timestamp: 1,
+        },
+    );
+    vault.set_position(&shared::Position {
+        user: user.clone(),
+        collateral: soroban_sdk::vec![
+            &env,
+            shared::CollateralAsset {
+                asset: collateral_asset.clone(),
+                amount: COLLATERAL_BALANCE,
+            },
+        ],
+    });
+
+    vault.set_collateral_value(&user, &COLLATERAL_VALUE);
+    pool.set_debt(&user, &DEBT);
+    vault.set_health_factor(&user, &HEALTH_FACTOR_UNHEALTHY);
+
+    Env_ {
+        env,
+        engine,
+        engine_addr: engine_id,
+        vault,
+        vault_addr: vault_id,
+        pool,
+        pool_addr: pool_id,
+        oracle,
+        oracle_addr: oracle_id,
+        admin,
+        liquidator,
+        user,
+        borrow_asset,
+        borrow_token,
+        collateral_asset,
+        collateral_token,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// is_liquidatable
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_is_liquidatable_false_when_healthy_or_no_debt() {
+    let ctx = setup();
+
+    // Unhealthy + debt -> liquidatable.
+    assert!(ctx.engine.is_liquidatable(&ctx.user));
+
+    // No debt -> never liquidatable, regardless of health factor.
+    ctx.pool.set_debt(&ctx.user, &0);
+    assert!(!ctx.engine.is_liquidatable(&ctx.user));
+
+    // Debt present but healthy -> not liquidatable.
+    ctx.pool.set_debt(&ctx.user, &DEBT);
+    ctx.vault
+        .set_health_factor(&ctx.user, &HEALTH_FACTOR_HEALTHY);
+    assert!(!ctx.engine.is_liquidatable(&ctx.user));
+}
+
+// ---------------------------------------------------------------------------
+// liquidate: happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_liquidate_success_repays_seizes_and_pays_bonus() {
+    let ctx = setup();
+
+    let result = ctx.engine.liquidate(&ctx.liquidator, &ctx.user, &DEBT);
+
+    assert_eq!(result.user, ctx.user);
+    assert_eq!(result.repaid, EXPECTED_PARTIAL_REPAY);
+
+    let bonus = expected_bonus(EXPECTED_PARTIAL_REPAY);
+    assert_eq!(result.bonus, bonus);
+    assert_eq!(result.seized, EXPECTED_PARTIAL_REPAY + bonus);
+
+    // Liquidator paid `repaid` of the borrow asset and received the seized
+    // collateral (1:1 token units, given the fixture's price/decimals).
+    assert_eq!(
+        ctx.borrow_token.balance(&ctx.liquidator),
+        1_000_000_000_000 - EXPECTED_PARTIAL_REPAY
+    );
+    assert_eq!(
+        ctx.collateral_token.balance(&ctx.liquidator),
+        EXPECTED_PARTIAL_REPAY + bonus
+    );
+    assert_eq!(
+        ctx.collateral_token.balance(&ctx.vault_addr),
+        COLLATERAL_BALANCE - (EXPECTED_PARTIAL_REPAY + bonus)
+    );
+
+    // Debt fell by the repaid amount (mock pool tracks this via repay_for).
+    assert_eq!(
+        ctx.pool.get_user_debt(&ctx.user),
+        DEBT - EXPECTED_PARTIAL_REPAY
+    );
+}
+
+#[test]
+fn test_liquidate_respects_max_repay_amount() {
+    let ctx = setup();
+
+    let max_repay = 1_000_000_000i128;
+    assert!(max_repay < EXPECTED_PARTIAL_REPAY);
+
+    let result = ctx.engine.liquidate(&ctx.liquidator, &ctx.user, &max_repay);
+
+    assert_eq!(result.repaid, max_repay);
+    let bonus = expected_bonus(max_repay);
+    assert_eq!(result.bonus, bonus);
+    assert_eq!(result.seized, max_repay + bonus);
+    assert_eq!(
+        ctx.borrow_token.balance(&ctx.liquidator),
+        1_000_000_000_000 - max_repay
+    );
+    assert_eq!(
+        ctx.collateral_token.balance(&ctx.liquidator),
+        max_repay + bonus
+    );
+}
+
+// ---------------------------------------------------------------------------
+// liquidate: rejections
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_liquidate_rejects_healthy_user() {
+    let ctx = setup();
+    ctx.vault
+        .set_health_factor(&ctx.user, &HEALTH_FACTOR_HEALTHY);
+
+    let res = ctx.engine.try_liquidate(&ctx.liquidator, &ctx.user, &DEBT);
+
+    assert_eq!(res, Err(Ok(EngineError::NotLiquidatable)));
+}
+
+#[test]
+fn test_liquidate_rejects_self_liquidation() {
+    let ctx = setup();
+
+    let res = ctx.engine.try_liquidate(&ctx.user, &ctx.user, &DEBT);
+
+    assert_eq!(res, Err(Ok(EngineError::Unauthorized)));
+}
+
+#[test]
+fn test_liquidate_rejects_non_positive_max_repay() {
+    let ctx = setup();
+
+    let res_zero = ctx.engine.try_liquidate(&ctx.liquidator, &ctx.user, &0);
+    assert_eq!(res_zero, Err(Ok(EngineError::InvalidAmount)));
+
+    let res_negative = ctx.engine.try_liquidate(&ctx.liquidator, &ctx.user, &-1);
+    assert_eq!(res_negative, Err(Ok(EngineError::InvalidAmount)));
+}
+
+#[test]
+fn test_liquidate_requires_liquidator_auth() {
+    // No `mock_all_auths` / explicit auth for the liquidator: the very first
+    // `liquidator.require_auth()` in `liquidate` must fail the call.
+    let env = Env::default();
+
+    let engine_id = env.register(LiquidationContract, ());
+    let engine = LiquidationContractClient::new(&env, &engine_id);
+
+    let liquidator = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let res = engine.try_liquidate(&liquidator, &user, &1_000);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_liquidate_fails_if_vault_engine_mismatch() {
+    let ctx = setup();
+
+    let other_engine = Address::generate(&ctx.env);
+    ctx.vault.set_liquidation_engine(&other_engine);
+
+    let res = ctx.engine.try_liquidate(&ctx.liquidator, &ctx.user, &DEBT);
+
+    assert_eq!(res, Err(Ok(EngineError::Unauthorized)));
+}


### PR DESCRIPTION
## **User description**
# Summary

Closes #630 

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #<!-- add issue number -->
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Implements permissionless liquidation in `contracts/liquidation-engine/src/liquidate.rs`:

- **`is_liquidatable`**: requires an initialized engine, loads accrued debt via `pool.get_user_debt`, returns `false` when debt is zero, otherwise returns `vault.get_health_factor(user) < 10_000`.
- **`liquidate(liquidator, user, max_repay_amount)`**:
  1. `liquidator.require_auth()`; rejects self-liquidation (`Unauthorized`).
  2. Rejects non-positive `max_repay_amount` (`InvalidAmount`).
  3. Requires stored vault/pool/oracle and that `vault.get_liquidation_engine()` matches the current contract (`Unauthorized`).
  4. Rejects healthy positions (`NotLiquidatable`).
  5. Caps the repay at `min(max_repay_amount, calculate_partial_repayment(user))`.
  6. Pulls the borrow asset from the liquidator into the engine, then calls `pool.repay_for`.
  7. Computes the 8% bonus and the seized value (`repay + bonus`), converting to token units via the vault's asset decimals and the oracle price, always rounding up (`ceil_div`) so the protocol never under-seizes.
  8. Seizes collateral starting from the user's largest-balance asset (ties broken by `get_position` order), moving to the next asset when a balance is insufficient, failing `InvalidAmount` if collateral runs out.
  9. Calls `vault.seize_collateral` per slice and forwards the seized tokens to the liquidator.
  10. Emits `Liquidated { user, liquidator, repaid, seized, bonus }` and returns `LiquidationResult`.

Also extends the local `Vault`/`Pool` contract-client traits with `get_position`, `get_asset_config`, `get_liquidation_engine`, and `get_borrow_asset`, and adds a local `Oracle` client using `shared::types::PriceData` (matching `oracle-adapter`'s 3-field price, not the vault's 2-field one). `seize_collateral`/`execute_seize` signatures in the vault were **not** changed.

### Tests

Added `contracts/liquidation-engine/src/tests/test_liquidate.rs` with all 8 required cases:

- `test_is_liquidatable_false_when_healthy_or_no_debt`
- `test_liquidate_success_repays_seizes_and_pays_bonus`
- `test_liquidate_respects_max_repay_amount`
- `test_liquidate_rejects_healthy_user`
- `test_liquidate_rejects_self_liquidation`
- `test_liquidate_rejects_non_positive_max_repay`
- `test_liquidate_requires_liquidator_auth`
- `test_liquidate_fails_if_vault_engine_mismatch`

Since `lending-pool`'s `repay_for`/`get_user_debt` and related cross-contract logic aren't implemented yet in this snapshot, the suite uses small local mock Vault/Pool/Oracle contracts (matching the real function signatures) to exercise the engine's logic in isolation.

```bash
cargo test -p liquidation-engine --all-features test_liquidate
```

All 18 tests in the crate pass; `cargo fmt --check` and `cargo clippy` are clean.

---


___

## **CodeAnt-AI Description**
Enable permissionless liquidation with collateral seizure and liquidator rewards

### What Changed
- Authorized liquidators can repay part of an unhealthy user's debt and receive collateral plus an 8% bonus
- Liquidations cap repayment at the requested amount and the protocol's partial-repayment limit
- Collateral is selected from the user's largest balances and converted using asset prices and decimals, with rounding that prevents under-seizure
- Healthy positions, zero-debt users, self-liquidation, invalid repayment amounts, missing setup, and unauthorized engine registrations are rejected
- Added coverage for successful liquidations, repayment limits, collateral transfers, debt reduction, authorization, and rejection cases

### Impact
`✅ Permissionless liquidations`
`✅ 8% liquidator collateral rewards`
`✅ Fewer under-seized collateral outcomes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
