### PR TITLE
feat(pool): implement third-party repay_for for permissionless liquid…

### DIFF
--- a/contracts/lending-pool/src/repay.rs
+++ b/contracts/lending-pool/src/repay.rs
@@ -8,11 +8,19 @@ use crate::events;
 use crate::storage;
 use crate::types::PauseFlag;
 
-/// Applies `amount` of `borrow_asset` to `user`'s debt, interest first, then
-/// principal. Pulls `min(amount, total_debt)` from `user`.
-pub fn repay(env: Env, user: Address, asset: Address, amount: i128) -> Result<(), PoolError> {
-    user.require_auth();
+/// Interest first, then principal. Returns `(interest_paid, principal_paid)`.
+fn split_repay(payment: i128, accrued_interest: i128) -> (i128, i128) {
+    let interest_paid = payment.min(accrued_interest);
+    (interest_paid, payment - interest_paid)
+}
 
+fn apply_repay(
+    env: Env,
+    payer: Address,
+    user: Address,
+    asset: Address,
+    amount: i128,
+) -> Result<(), PoolError> {
     if amount <= 0 {
         return Err(PoolError::InvalidAmount);
     }
@@ -34,8 +42,7 @@ pub fn repay(env: Env, user: Address, asset: Address, amount: i128) -> Result<()
     }
 
     let payment = amount.min(total_debt);
-    let interest_paid = payment.min(user_debt.accrued_interest);
-    let principal_paid = payment - interest_paid;
+    let (interest_paid, principal_paid) = split_repay(payment, user_debt.accrued_interest);
 
     let remaining = total_debt - payment;
     if remaining > 0 && remaining < shared::MIN_REMAINING_DEBT {
@@ -43,7 +50,7 @@ pub fn repay(env: Env, user: Address, asset: Address, amount: i128) -> Result<()
     }
 
     let token_client = token::Client::new(&env, &borrow_asset);
-    token_client.transfer(&user, env.current_contract_address(), &payment);
+    token_client.transfer(&payer, env.current_contract_address(), &payment);
 
     user_debt.accrued_interest = user_debt
         .accrued_interest
@@ -77,6 +84,15 @@ pub fn repay(env: Env, user: Address, asset: Address, amount: i128) -> Result<()
     Ok(())
 }
 
+/// Applies `amount` of `borrow_asset` to `user`'s debt, interest first, then
+/// principal. Pulls `min(amount, total_debt)` from `user`.
+pub fn repay(env: Env, user: Address, asset: Address, amount: i128) -> Result<(), PoolError> {
+    user.require_auth();
+    apply_repay(env, user.clone(), user, asset, amount)
+}
+
+/// Applies `amount` of `borrow_asset` to `user`'s debt, interest first, then
+/// principal. Pulls `min(amount, total_debt)` from `payer`.
 pub fn repay_for(
     env: Env,
     payer: Address,
@@ -84,8 +100,8 @@ pub fn repay_for(
     asset: Address,
     amount: i128,
 ) -> Result<(), PoolError> {
-    let _ = (env, payer, user, asset, amount);
-    Err(PoolError::NotImplemented)
+    payer.require_auth();
+    apply_repay(env, payer, user, asset, amount)
 }
 
 pub fn is_liquidatable(env: Env, user: Address) -> Result<bool, PoolError> {

--- a/contracts/lending-pool/src/tests/mod.rs
+++ b/contracts/lending-pool/src/tests/mod.rs
@@ -2,4 +2,5 @@ mod test_admin;
 mod test_pause;
 
 mod test_repay;
+mod test_repay_for;
 mod test_supply;

--- a/contracts/lending-pool/src/tests/test_repay_for.rs
+++ b/contracts/lending-pool/src/tests/test_repay_for.rs
@@ -1,0 +1,290 @@
+#![cfg(test)]
+
+use super::super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{contract, contractimpl, token, Address, Env, Symbol};
+
+#[contract]
+pub struct MockVaultContract;
+
+#[contractimpl]
+impl MockVaultContract {
+    pub fn set_health_factor(env: Env, user: Address, hf: i128) {
+        env.storage().persistent().set(&user, &hf);
+    }
+
+    pub fn get_health_factor(env: Env, user: Address) -> i128 {
+        env.storage().persistent().get(&user).unwrap_or(15_000)
+    }
+
+    pub fn get_collateral_value(_env: Env, _user: Address) -> i128 {
+        0
+    }
+
+    pub fn get_position(_env: Env, _user: Address) -> shared::Position {
+        unimplemented!()
+    }
+
+    pub fn get_asset_config(_env: Env, _asset: Address) -> shared::AssetConfig {
+        unimplemented!()
+    }
+}
+
+fn setup_env() -> (
+    Env,
+    PoolContractClient<'static>,
+    Address,
+    Address,
+    MockVaultContractClient<'static>,
+    Address,
+    Address,
+    token::Client<'static>,
+    token::StellarAssetClient<'static>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PoolContract, ());
+    let client = PoolContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let vault_id = env.register(MockVaultContract, ());
+    let vault_client = MockVaultContractClient::new(&env, &vault_id);
+    let oracle = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+    let token_contract_id = token_contract.address();
+    let token_client = token::Client::new(&env, &token_contract_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract_id);
+
+    let interest_rate_bps = 1000; // 10% annual interest
+    client.initialize(
+        &admin,
+        &vault_id,
+        &oracle,
+        &token_contract_id,
+        &interest_rate_bps,
+    );
+
+    (
+        env,
+        client,
+        admin,
+        user,
+        vault_client,
+        vault_id,
+        token_contract_id,
+        token_client,
+        token_admin_client,
+    )
+}
+
+fn set_user_debt(
+    env: &Env,
+    pool_address: &Address,
+    user: &Address,
+    principal: i128,
+    accrued_interest: i128,
+    interest_rate_bps: u32,
+    last_accrual_at: u64,
+) {
+    env.as_contract(pool_address, || {
+        let debt = Debt {
+            principal,
+            accrued_interest,
+            interest_rate_bps,
+            last_accrual_at,
+        };
+        storage::set_debt(env, user, &debt);
+        let current_borrowed = storage::get_total_borrowed(env);
+        storage::set_total_borrowed(env, current_borrowed + principal);
+    });
+}
+
+#[test]
+fn test_repay_for_third_party_pays_without_borrower_auth() {
+    let (env, client, _admin, user, _vault, _vault_id, token_id, token_client, token_admin) =
+        setup_env();
+    let payer = Address::generate(&env);
+
+    let initial_principal = 100_000_000i128;
+    let initial_interest = 10_000_000i128;
+    let now = env.ledger().timestamp();
+    set_user_debt(
+        &env,
+        &client.address,
+        &user,
+        initial_principal,
+        initial_interest,
+        1000,
+        now,
+    );
+
+    token_admin.mint(&payer, &5_000_000);
+
+    client.repay_for(&payer, &user, &token_id, &5_000_000);
+
+    let auths = env.auths();
+    assert!(auths.iter().any(|(addr, _)| addr == &payer));
+    assert!(auths.iter().all(|(addr, _)| addr != &user));
+
+    let updated_debt = client.get_debt(&user);
+    assert_eq!(updated_debt.accrued_interest, 5_000_000);
+    assert_eq!(updated_debt.principal, 100_000_000);
+    assert_eq!(token_client.balance(&payer), 0);
+    assert_eq!(token_client.balance(&user), 0);
+    assert_eq!(token_client.balance(&client.address), 5_000_000);
+}
+
+#[test]
+fn test_repay_for_interest_before_principal() {
+    let (env, client, _admin, user, _vault, _vault_id, token_id, token_client, token_admin) =
+        setup_env();
+    let payer = Address::generate(&env);
+
+    let initial_principal = 100_000_000i128;
+    let initial_interest = 10_000_000i128;
+    let now = env.ledger().timestamp();
+    set_user_debt(
+        &env,
+        &client.address,
+        &user,
+        initial_principal,
+        initial_interest,
+        1000,
+        now,
+    );
+
+    token_admin.mint(&payer, &5_000_000);
+
+    client.repay_for(&payer, &user, &token_id, &5_000_000);
+
+    let updated_debt = client.get_debt(&user);
+    assert_eq!(updated_debt.accrued_interest, 5_000_000);
+    assert_eq!(updated_debt.principal, 100_000_000);
+    assert_eq!(token_client.balance(&payer), 0);
+    assert_eq!(token_client.balance(&client.address), 5_000_000);
+
+    env.as_contract(&client.address, || {
+        assert_eq!(storage::get_total_borrowed(&env), 100_000_000);
+    });
+}
+
+#[test]
+fn test_repay_for_full_clears_debt() {
+    let (env, client, _admin, user, _vault, _vault_id, token_id, token_client, token_admin) =
+        setup_env();
+    let payer = Address::generate(&env);
+
+    let initial_principal = 100_000_000i128;
+    let initial_interest = 10_000_000i128;
+    let now = env.ledger().timestamp();
+    set_user_debt(
+        &env,
+        &client.address,
+        &user,
+        initial_principal,
+        initial_interest,
+        1000,
+        now,
+    );
+
+    token_admin.mint(&payer, &150_000_000);
+
+    client.repay_for(&payer, &user, &token_id, &150_000_000);
+
+    env.as_contract(&client.address, || {
+        assert_eq!(storage::get_debt(&env, &user), None);
+        assert_eq!(storage::get_total_borrowed(&env), 0);
+    });
+
+    assert_eq!(client.get_user_debt(&user), 0);
+    assert_eq!(token_client.balance(&payer), 40_000_000);
+    assert_eq!(token_client.balance(&user), 0);
+    assert_eq!(token_client.balance(&client.address), 110_000_000);
+}
+
+#[test]
+fn test_repay_for_zero_or_negative_fails() {
+    let (env, client, _admin, user, _vault, _vault_id, token_id, _token_client, token_admin) =
+        setup_env();
+    let payer = Address::generate(&env);
+
+    token_admin.mint(&payer, &1000);
+
+    let res_zero = client.try_repay_for(&payer, &user, &token_id, &0);
+    assert!(res_zero.is_err());
+
+    let res_neg = client.try_repay_for(&payer, &user, &token_id, &-100);
+    assert!(res_neg.is_err());
+}
+
+#[test]
+fn test_repay_for_when_paused_fails() {
+    let (env, client, _admin, user, _vault, _vault_id, token_id, _token_client, token_admin) =
+        setup_env();
+    let payer = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    set_user_debt(&env, &client.address, &user, 100_000_000, 0, 1000, now);
+    token_admin.mint(&payer, &100_000_000);
+
+    client.pause_operation(&PauseFlag::Repay, &Symbol::new(&env, "test"));
+
+    let res = client.try_repay_for(&payer, &user, &token_id, &50_000_000);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_repay_for_wrong_asset_fails() {
+    let (env, client, _admin, user, _vault, _vault_id, _token_id, _token_client, _token_admin) =
+        setup_env();
+    let payer = Address::generate(&env);
+
+    let wrong_token_admin = Address::generate(&env);
+    let wrong_token = env
+        .register_stellar_asset_contract_v2(wrong_token_admin)
+        .address();
+
+    let res = client.try_repay_for(&payer, &user, &wrong_token, &1000);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_repay_for_dust_remaining_fails_unless_full_close() {
+    let (env, client, _admin, user, _vault, _vault_id, token_id, _token_client, token_admin) =
+        setup_env();
+    let payer = Address::generate(&env);
+
+    let total_debt = shared::MIN_REMAINING_DEBT + 50;
+    let now = env.ledger().timestamp();
+    set_user_debt(&env, &client.address, &user, total_debt, 0, 1000, now);
+    token_admin.mint(&payer, &total_debt);
+
+    let res_dust = client.try_repay_for(&payer, &user, &token_id, &100);
+    assert!(res_dust.is_err());
+
+    let res_full = client.try_repay_for(&payer, &user, &token_id, &total_debt);
+    assert!(res_full.is_ok());
+}
+
+#[test]
+fn test_repay_still_requires_borrower_auth() {
+    let (env, client, _admin, user, _vault, _vault_id, token_id, _token_client, token_admin) =
+        setup_env();
+
+    let now = env.ledger().timestamp();
+    set_user_debt(&env, &client.address, &user, 100_000_000, 0, 1000, now);
+    token_admin.mint(&user, &50_000_000);
+
+    client.repay(&user, &token_id, &20_000_000);
+    let auths = env.auths();
+    assert!(auths.iter().any(|(addr, _)| addr == &user));
+
+    env.set_auths(&[]);
+    let res = client.try_repay(&user, &token_id, &20_000_000);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## **User description**
# feat(pool): implement third-party repay_for for permissionless liquidation

## Summary
- Anyone can repay a borrower's debt via `repay_for` without borrower auth
- Interest-first split, dust floor, and `Repaid` accounting are shared with `repay`
- Borrower-only `repay` still requires the user to authorize

## Why
- Liquidators and the engine cannot use `repay` because it requires borrower auth. `repay_for` was declared but still returned `NotImplemented`.

## How it was tested
- `cargo test -p lending-pool --all-features test_repay_for`
- `cargo test -p lending-pool --all-features test_repay`
- New tests cover third-party payment, interest-before-principal, full close, pause, wrong asset, dust remaining, and that `repay` still requires borrower auth

Closes #628

## Test plan
- [ ] `cargo test -p lending-pool --all-features test_repay_for`
- [ ] `cargo test -p lending-pool --all-features test_repay`
- [ ] Confirm `repay_for` pulls tokens from the payer and emits `Repaid` for the debtor

---

# 🚀 Alien Protocol Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #628
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

`repay` still requires the borrower to authorize, so liquidators cannot use it. This implements `repay_for(payer, user, asset, amount)`:

- `payer.require_auth()` (not `user`)
- Rejects `amount <= 0` (`InvalidAmount`)
- Asset must equal the stored borrow asset (`UnsupportedAsset`)
- Honors the `Repay` pause flag (`RepayPaused`)
- Accrues first; no debt → `NoDebt`
- Pulls `min(amount, total_debt)` from the **payer**
- Applies interest first, then principal via a shared `split_repay` helper
- Rejects dust remaining below `MIN_REMAINING_DEBT` unless the position closes (`BelowMinDebt`)
- Decreases `TotalBorrowed` by the principal portion only
- Clears storage at zero
- Emits `Repaid` with `user` as the debtor and `interest_paid` / `principal_paid`

`repay` and `repay_for` share `apply_repay` so the split cannot diverge. The `repay` signature and borrower-auth path are unchanged. Engine `liquidate` is out of scope.

Files:
- `contracts/lending-pool/src/repay.rs`
- `contracts/lending-pool/src/tests/mod.rs`
- `contracts/lending-pool/src/tests/test_repay_for.rs`

---

## 📸 Evidence (A Loom/Cap video is required as evidence, we WON'T merge if there's no proof)

Attach on the PR:

- Screenshot of `repay_for` and the shared `split_repay` helper in `repay.rs`
- Screenshot of `test_repay_for_third_party_pays_without_borrower_auth ... ok`

```text
cargo test -p lending-pool --all-features test_repay_for
# 8 passed

cargo test -p lending-pool --all-features test_repay
# 17 passed
```

---

## ⏰ Time spent breakdown

- Read issue #628 and existing `repay` / issue 9 tests
- Extract `split_repay` + `apply_repay`, implement `repay_for`
- Add `test_repay_for.rs` mandatory cases
- Run `test_repay_for` and `test_repay`, fmt, clippy

---

## 🌌 Comments

Do not change `repay` auth. Do not implement engine `liquidate` here.

Thank you for contributing to Alien Protocol !!


___

## **CodeAnt-AI Description**
Enable third-party debt repayment without borrower authorization

### What Changed
- Authorized payers can repay a borrower's debt through `repay_for`, allowing liquidators and other services to pay on the borrower's behalf
- Repayments are applied to accrued interest before principal, emit repayment accounting for the borrower, and close the debt when fully paid
- Existing safety rules remain enforced for invalid amounts, unsupported assets, paused repayments, and unacceptably small remaining balances
- Borrower-authorized `repay` continues to require the borrower’s approval

### Impact
`✅ Permissionless liquidations can repay borrower debt`
`✅ Clear interest-first debt reduction`
`✅ Fewer failed repayments from invalid or unsafe amounts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
