### PR TITLE
chore: add rust-toolchain.toml so local and CI match (#644)

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -19,9 +19,6 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-          targets: wasm32-unknown-unknown
 
       - name: Build collateral-vault WASM for upgrade tests
         run: cargo build -p collateral-vault --target wasm32-unknown-unknown --release
@@ -45,8 +42,6 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
 
       - name: Build Soroban contracts
         run: |
@@ -69,8 +64,6 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
 
       - name: Build collateral-vault WASM for upgrade tests
         run: cargo build -p collateral-vault --target wasm32-unknown-unknown --release

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel  = "stable"
+components = ["rustfmt", "clippy"]
+targets  = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## **User description**
- Add rust-toolchain.toml with channel=stable, components rustfmt+clippy, and target wasm32-unknown-unknown — matching what CI already used.
- Remove inline with: toolchain params from all three CI Setup Rust steps so dtolnay/rust-toolchain reads the file instead of overriding it. Contributors now automatically pick up the same toolchain locally.

closes #644


___

## **CodeAnt-AI Description**
Align local Rust setup and CI checks

### What Changed
- Local development and CI now use the same stable Rust toolchain
- Rust formatting, linting, and WebAssembly builds use the toolchain’s shared configuration
- Contributors no longer need to manually configure the required Rust components or WebAssembly target

### Impact
`✅ Consistent local and CI checks`
`✅ Fewer environment setup errors`
`✅ Reliable WebAssembly contract builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
