### PR TITLE
fix(oracle): reject stale and future timestamps in set_price (#647)

### DIFF
--- a/contracts/oracle-adapter/src/lib.rs
+++ b/contracts/oracle-adapter/src/lib.rs
@@ -86,6 +86,20 @@ impl OracleContract {
             soroban_sdk::panic_with_error!(&env, OracleError::InvalidTimestamp);
         }
 
+        // Reject timestamps that are not strictly newer than the last stored price.
+        // This prevents feeders from overwriting a fresh price with stale data.
+        if let Some(existing) = storage::get_price(&env, &asset) {
+            if timestamp <= existing.timestamp {
+                soroban_sdk::panic_with_error!(&env, OracleError::InvalidTimestamp);
+            }
+        }
+
+        // Reject timestamps that lie in the future relative to the current ledger.
+        // A price whose timestamp exceeds ledger time is fabricated data.
+        if timestamp > env.ledger().timestamp() {
+            soroban_sdk::panic_with_error!(&env, OracleError::InvalidTimestamp);
+        }
+
         let data = PriceData {
             price,
             timestamp,

--- a/contracts/oracle-adapter/src/tests/mod.rs
+++ b/contracts/oracle-adapter/src/tests/mod.rs
@@ -1,10 +1,13 @@
 use super::*;
-use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::testutils::{Address as _, Events, Ledger as _};
 use soroban_sdk::{Address, Env, Symbol, TryFromVal};
 
 pub(crate) fn setup_env() -> (Env, OracleContractClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
+    // Set a high initial ledger timestamp so set_price calls with typical test
+    // timestamps (e.g. 1_000–100_000) are always <= ledger time.
+    env.ledger().set_timestamp(1_000_000_000);
 
     let contract_id = env.register(OracleContract, ());
     let client = OracleContractClient::new(&env, &contract_id);

--- a/contracts/oracle-adapter/src/tests/test_get_price_or_fail.rs
+++ b/contracts/oracle-adapter/src/tests/test_get_price_or_fail.rs
@@ -9,6 +9,8 @@ use soroban_sdk::{Address, Env, Error};
 fn setup_env() -> (Env, OracleContractClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
+    // Set timestamp >= price timestamps used in these tests (all ≤ 1_000).
+    env.ledger().set_timestamp(1_000);
 
     let contract_id = env.register(OracleContract, ());
     let client = OracleContractClient::new(&env, &contract_id);

--- a/contracts/oracle-adapter/src/tests/test_price.rs
+++ b/contracts/oracle-adapter/src/tests/test_price.rs
@@ -2,13 +2,16 @@
 
 extern crate std;
 
-use crate::{OracleContract, OracleContractClient, PriceData};
-use soroban_sdk::testutils::{Address as _, Events, MockAuth, MockAuthInvoke};
+use crate::{OracleContract, OracleContractClient, OracleError, PriceData};
+use soroban_sdk::testutils::{Address as _, Events, Ledger as _, MockAuth, MockAuthInvoke};
 use soroban_sdk::{Address, Env, Map, Symbol, TryFromVal, Val, Vec};
 
 fn setup_env_mock_all_auths() -> (Env, OracleContractClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
+    // Start ledger timestamp well above typical test timestamps (≤ 100_000)
+    // so the future-timestamp guard in set_price never rejects test data.
+    env.ledger().set_timestamp(1_000_000_000);
 
     let contract_id = env.register(OracleContract, ());
     let client = OracleContractClient::new(&env, &contract_id);
@@ -21,6 +24,8 @@ fn setup_env_mock_all_auths() -> (Env, OracleContractClient<'static>, Address) {
 
 fn setup_env_no_mock_auths() -> (Env, OracleContractClient<'static>, Address) {
     let env = Env::default();
+    // Start ledger timestamp well above typical test timestamps.
+    env.ledger().set_timestamp(1_000_000_000);
 
     let contract_id = env.register(OracleContract, ());
     let client = OracleContractClient::new(&env, &contract_id);
@@ -131,7 +136,8 @@ fn test_get_price_returns_correct_data() {
     let asset = Address::generate(&env);
 
     let price = 1_000_000_i128;
-    let timestamp = 1_234_567_890_u64;
+    // Keep timestamp <= ledger time (1_000_000_000 set in setup_env_mock_all_auths).
+    let timestamp = 999_999_999_u64;
 
     client.set_price(&admin, &asset, &price, &timestamp);
 
@@ -166,4 +172,96 @@ fn test_set_price_overwrites_existing() {
     let second = client.get_price(&asset).unwrap();
     assert_eq!(second.price, 222);
     assert_eq!(second.timestamp, 200);
+}
+
+// ── Issue #647: stale and future timestamp guards ────────────────────────────
+
+/// set_price must reject a timestamp older than the last stored price timestamp.
+/// Acceptance criterion: "Older timestamp for the same asset fails".
+#[test]
+fn test_set_price_older_timestamp_rejected() {
+    let (env, client, admin) = setup_env_mock_all_auths();
+    let asset = Address::generate(&env);
+
+    // First write at timestamp 5_000.
+    client.set_price(&admin, &asset, &100_i128, &5_000_u64);
+
+    // Second write with an older timestamp must fail with InvalidTimestamp.
+    let result = client.try_set_price(&admin, &asset, &200_i128, &4_999_u64);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::InvalidTimestamp as u32)
+    );
+}
+
+/// set_price must also reject a timestamp equal to the last stored price timestamp
+/// (requires *strictly* newer, not merely non-decreasing).
+#[test]
+fn test_set_price_equal_timestamp_rejected() {
+    let (env, client, admin) = setup_env_mock_all_auths();
+    let asset = Address::generate(&env);
+
+    client.set_price(&admin, &asset, &100_i128, &5_000_u64);
+
+    let result = client.try_set_price(&admin, &asset, &200_i128, &5_000_u64);
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::InvalidTimestamp as u32)
+    );
+}
+
+/// set_price must reject a timestamp that exceeds the current ledger time.
+/// Acceptance criterion: "Timestamp after ledger time fails".
+#[test]
+fn test_set_price_future_timestamp_rejected() {
+    let (env, client, admin) = setup_env_mock_all_auths();
+    let asset = Address::generate(&env);
+
+    // Pin the ledger to a known time, then try to submit a price timestamped
+    // one second in the future.
+    let ledger_now: u64 = 50_000;
+    env.ledger().set_timestamp(ledger_now);
+
+    let result = client.try_set_price(&admin, &asset, &300_i128, &(ledger_now + 1));
+    assert!(result.is_err());
+    let err = result.err().unwrap().unwrap();
+    assert_eq!(
+        err,
+        soroban_sdk::Error::from_contract_error(OracleError::InvalidTimestamp as u32)
+    );
+}
+
+/// A price timestamped exactly at ledger time is valid (boundary: timestamp == ledger).
+#[test]
+fn test_set_price_at_ledger_timestamp_succeeds() {
+    let (env, client, admin) = setup_env_mock_all_auths();
+    let asset = Address::generate(&env);
+
+    let ledger_now: u64 = 50_000;
+    env.ledger().set_timestamp(ledger_now);
+
+    // timestamp == ledger time must be accepted.
+    client.set_price(&admin, &asset, &300_i128, &ledger_now);
+    let stored = client.get_price(&asset).unwrap();
+    assert_eq!(stored.price, 300);
+    assert_eq!(stored.timestamp, ledger_now);
+}
+
+/// The very first set_price for a new asset succeeds even when no prior price
+/// exists (stale-check branch is not taken).
+/// Acceptance criterion: "First valid set_price still succeeds".
+#[test]
+fn test_set_price_first_write_succeeds() {
+    let (env, client, admin) = setup_env_mock_all_auths();
+    let asset = Address::generate(&env);
+
+    // No prior price — should succeed without hitting the stale guard.
+    client.set_price(&admin, &asset, &500_i128, &1_000_u64);
+    let stored = client.get_price(&asset).unwrap();
+    assert_eq!(stored.price, 500);
+    assert_eq!(stored.timestamp, 1_000);
 }


### PR DESCRIPTION
## **User description**
Two new guards added to set_price, immediately after the existing price > 0 and timestamp != 0 checks:

1. Stale-price guard: if a price already exists for the asset, require timestamp > existing.timestamp. Equal or older timestamps are rejected with OracleError::InvalidTimestamp. This prevents a feeder from overwriting a fresh price with stale data.

2. Future-timestamp guard: require timestamp <= env.ledger().timestamp(). A price timestamped beyond the current ledger time is fabricated data and is rejected with OracleError::InvalidTimestamp.

Test changes:
- All setup_env helpers now initialise the ledger timestamp to 1_000_000_000 so existing tests with small timestamps (< 100_000) continue to pass the new future-timestamp guard.
- test_get_price_or_fail setup_env sets ledger to 1_000 (matching the max price timestamp used in those tests) so freshness tests that advance the clock with set_timestamp() still work correctly.
- test_price.rs: added OracleError + Ledger imports and five new tests:
    * test_set_price_older_timestamp_rejected
    * test_set_price_equal_timestamp_rejected
    * test_set_price_future_timestamp_rejected
    * test_set_price_at_ledger_timestamp_succeeds
    * test_set_price_first_write_succeeds

No RedStone push/pull payload parsing is changed.  

closes #647


___

## **CodeAnt-AI Description**
Reject stale and future oracle price timestamps

### What Changed
- Price updates for an asset are rejected when their timestamp is older than or equal to the stored price timestamp
- Price updates with timestamps later than the current ledger time are rejected
- First-time prices and updates timestamped exactly at the ledger time remain valid
- Added coverage for stale, duplicate, future, boundary, and first-write timestamp cases

### Impact
`✅ Prevents stale oracle prices from overwriting current data`
`✅ Blocks future-dated price submissions`
`✅ Preserves valid first-time and boundary-timestamp updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
