### PR TITLE
fix(pool): keep vault ≠ oracle when rotating addresses

### DIFF
--- a/contracts/lending-pool/src/admin.rs
+++ b/contracts/lending-pool/src/admin.rs
@@ -69,6 +69,12 @@ pub fn set_vault(env: Env, vault: Address) -> Result<(), PoolError> {
     let admin = storage::get_admin(&env).ok_or(PoolError::NotInitialized)?;
     admin.require_auth();
 
+    if let Some(current_oracle) = storage::get_oracle(&env) {
+        if vault == current_oracle {
+            return Err(PoolError::InvalidAddress);
+        }
+    }
+
     storage::set_vault(&env, &vault);
     Ok(())
 }
@@ -76,6 +82,12 @@ pub fn set_vault(env: Env, vault: Address) -> Result<(), PoolError> {
 pub fn set_oracle(env: Env, oracle: Address) -> Result<(), PoolError> {
     let admin = storage::get_admin(&env).ok_or(PoolError::NotInitialized)?;
     admin.require_auth();
+
+    if let Some(current_vault) = storage::get_vault(&env) {
+        if oracle == current_vault {
+            return Err(PoolError::InvalidAddress);
+        }
+    }
 
     storage::set_oracle(&env, &oracle);
     Ok(())

--- a/contracts/lending-pool/src/tests/test_admin.rs
+++ b/contracts/lending-pool/src/tests/test_admin.rs
@@ -73,7 +73,45 @@ fn test_initialize_vault_equals_oracle_fails() {
     let (_env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
 
     let res = client.try_initialize(&admin, &vault, &vault, &token_id, &500);
-    assert!(res.is_err());
+    assert_eq!(res, Err(Ok(crate::errors::PoolError::InvalidAddress)));
+}
+
+#[test]
+fn test_set_vault_equals_oracle_fails() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &500);
+
+    let res = client.try_set_vault(&oracle);
+    assert_eq!(res, Err(Ok(crate::errors::PoolError::InvalidAddress)));
+}
+
+#[test]
+fn test_set_oracle_equals_vault_fails() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &500);
+
+    let res = client.try_set_oracle(&vault);
+    assert_eq!(res, Err(Ok(crate::errors::PoolError::InvalidAddress)));
+}
+
+#[test]
+fn test_rotating_to_distinct_address_succeeds() {
+    let (env, client, admin, _user, vault, token_id, _token_client, _token_admin) = setup_env();
+    let oracle = Address::generate(&env);
+
+    client.initialize(&admin, &vault, &oracle, &token_id, &500);
+
+    let new_vault = Address::generate(&env);
+    client.set_vault(&new_vault);
+    assert_eq!(client.get_vault(), Some(new_vault));
+
+    let new_oracle = Address::generate(&env);
+    client.set_oracle(&new_oracle);
+    assert_eq!(client.get_oracle(), Some(new_oracle));
 }
 
 #[test]


### PR DESCRIPTION
## **User description**
## Description
Closes #649   by keeping `vault` and `oracle` distinct when rotating addresses. 

The `PoolContract::initialize` method already rejects when `vault == oracle`, but this invariant could previously be broken after initialization by calling `set_vault` with the current `oracle` address, or by calling `set_oracle` with the current `vault` address.

This PR adds checks in `set_vault` and `set_oracle` to reject the rotation if the new address equals the current address of the other role, returning `PoolError::InvalidAddress`.

## Changes Made
- Added a check in `set_vault` to return `PoolError::InvalidAddress` if the new vault address equals the currently stored `oracle`.
- Added a check in `set_oracle` to return `PoolError::InvalidAddress` if the new oracle address equals the currently stored `vault`.
- Added `test_set_vault_equals_oracle_fails` and `test_set_oracle_equals_vault_fails` in `contracts/lending-pool/src/tests/test_admin.rs`.
- Added `test_rotating_to_distinct_address_succeeds` to ensure valid rotations still work as expected.


___

## **CodeAnt-AI Description**
Prevent vault and oracle roles from sharing an address during rotation

### What Changed
- Rejects vault updates when the new vault matches the current oracle
- Rejects oracle updates when the new oracle matches the current vault
- Confirms valid rotations to distinct addresses continue to succeed

### Impact
`✅ Preserved separation between vault and oracle roles`
`✅ Clear invalid-address errors for conflicting rotations`
`✅ Safe address rotation remains supported`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented assigning the same address to both the lending pool’s vault and oracle.
  * Added validation when updating either address to ensure configuration remains valid.
  * Improved error reporting for invalid address assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->