### PR TITLE
fix(vault): use the same three-field PriceData as the oracle

### DIFF
--- a/contracts/collateral-vault/src/tests/test_pause.rs
+++ b/contracts/collateral-vault/src/tests/test_pause.rs
@@ -50,7 +50,11 @@ impl MockOracle {
     }
 
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
-        let price_data = types::PriceData { price, timestamp };
+        let price_data = types::PriceData {
+            price,
+            timestamp,
+            write_timestamp: env.ledger().timestamp(),
+        };
         env.storage().persistent().set(&asset, &price_data);
     }
 }

--- a/contracts/collateral-vault/src/tests/test_pool_integration.rs
+++ b/contracts/collateral-vault/src/tests/test_pool_integration.rs
@@ -31,9 +31,12 @@ impl MockOracle {
     }
 
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
-        env.storage()
-            .persistent()
-            .set(&asset, &types::PriceData { price, timestamp });
+        let price_data = types::PriceData {
+            price,
+            timestamp,
+            write_timestamp: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&asset, &price_data);
     }
 }
 

--- a/contracts/collateral-vault/src/tests/test_read_functions.rs
+++ b/contracts/collateral-vault/src/tests/test_read_functions.rs
@@ -43,7 +43,11 @@ impl MockOracleContract {
     }
 
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
-        let price_data = types::PriceData { price, timestamp };
+        let price_data = types::PriceData {
+            price,
+            timestamp,
+            write_timestamp: env.ledger().timestamp(),
+        };
         env.storage().persistent().set(&asset, &price_data);
     }
 }

--- a/contracts/collateral-vault/src/tests/test_risk.rs
+++ b/contracts/collateral-vault/src/tests/test_risk.rs
@@ -47,7 +47,11 @@ impl MockOracle {
     }
 
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
-        let price_data = types::PriceData { price, timestamp };
+        let price_data = types::PriceData {
+            price,
+            timestamp,
+            write_timestamp: env.ledger().timestamp(),
+        };
         env.storage().persistent().set(&asset, &price_data);
     }
 }

--- a/contracts/collateral-vault/src/tests/test_withdraw.rs
+++ b/contracts/collateral-vault/src/tests/test_withdraw.rs
@@ -46,7 +46,11 @@ impl MockOracle {
     }
 
     pub fn set_price(env: Env, asset: Address, price: i128, timestamp: u64) {
-        let price_data = types::PriceData { price, timestamp };
+        let price_data = types::PriceData {
+            price,
+            timestamp,
+            write_timestamp: env.ledger().timestamp(),
+        };
         env.storage().persistent().set(&asset, &price_data);
     }
 }

--- a/contracts/collateral-vault/src/types.rs
+++ b/contracts/collateral-vault/src/types.rs
@@ -130,10 +130,9 @@ pub enum DataKey {
     PauseMask,
 }
 
-/// Price data from the oracle.
-#[contracttype]
-#[derive(Clone, Debug, PartialEq)]
-pub struct PriceData {
-    pub price: i128,
-    pub timestamp: u64,
-}
+/// Price data returned by the oracle adapter. This is deliberately the same
+/// three-field type exposed by `shared` (and the oracle adapter) so the vault
+/// can decode `get_price` / `get_price_or_fail` results from the real oracle
+/// contract. The vault does not persist `PriceData`; it only consumes it from
+/// the oracle client.
+pub use shared::PriceData;

--- a/contracts/liquidation-engine/src/liquidate.rs
+++ b/contracts/liquidation-engine/src/liquidate.rs
@@ -35,11 +35,10 @@ pub trait Pool {
     fn get_borrow_asset(env: Env) -> Option<Address>;
 }
 
-/// Oracle client for the liquidation engine.
-///
-/// Declared locally (rather than reused from the vault or pool crates) because
-/// it must match `oracle-adapter`'s three-field `PriceData` (price, timestamp,
-/// write_timestamp), not the vault's two-field `PriceData`.
+/// Oracle client for the liquidation engine, matching `oracle-adapter`'s
+/// three-field `PriceData` (price, timestamp, write_timestamp). Both the vault
+/// and the engine now use this same shared `PriceData`, so cross-contract
+/// reads of `get_price`/`get_price_or_fail` decode consistently.
 #[soroban_sdk::contractclient(name = "OracleClient")]
 #[allow(dead_code)]
 pub trait Oracle {


### PR DESCRIPTION
## **User description**
The vault's `types::PriceData` only had `price` and `timestamp`, while the oracle adapter and `shared` expose a three-field `PriceData` (price, timestamp, write_timestamp). Cross-contract reads of `get_price` / `get_price_or_fail` would fail to decode when the vault talked to the real oracle adapter.

- collateral-vault/src/types.rs: replace the local two-field struct with `pub use shared::PriceData`. The vault does not persist PriceData, so this alias is safe.
- Update every mock oracle's set_price helper to store the three-field PriceData (write_timestamp set from the ledger timestamp).
- liquidation-engine/src/liquidate.rs: shorten the Oracle client comment now that vault and engine use the same shared PriceData.

No liquidation math changed.

closes #654


___

## **CodeAnt-AI Description**
Align vault price data with the oracle contract

### What Changed
- The vault now reads oracle prices using the same three-field price format as the real oracle adapter.
- Cross-contract price lookups now decode consistently instead of failing due to mismatched data.
- Test oracle data includes the write timestamp used by the shared format.

### Impact
`✅ Reliable vault price reads`
`✅ Compatible vault-to-oracle calls`
`✅ Consistent price data across contracts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oracle price handling by recording when each price was written.
  * Ensured consistent price data across the collateral vault, oracle adapter, and liquidation engine.
* **Tests**
  * Updated pricing scenarios to include write-time information, improving validation of oracle data behavior.
* **Documentation**
  * Clarified how price data is shared and interpreted across related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->