### PR TITLE
fix(ci): build WASM with wasm32v1-none like the docs

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -21,7 +21,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build collateral-vault WASM for upgrade tests
-        run: cargo build -p collateral-vault --target wasm32-unknown-unknown --release
+        run: cargo build -p collateral-vault --target wasm32v1-none --release
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -33,7 +33,7 @@ jobs:
         run: cargo check --verbose
 
   build:
-    name: Build Contracts (wasm32-unknown-unknown)
+    name: Build Contracts (wasm32v1-none)
     runs-on: ubuntu-latest
     needs: checks
 
@@ -50,7 +50,7 @@ jobs:
             -p lending-pool \
             -p liquidation-engine \
             -p oracle-adapter \
-            --target wasm32-unknown-unknown \
+            --target wasm32v1-none \
             --release \
             --verbose
 
@@ -66,7 +66,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build collateral-vault WASM for upgrade tests
-        run: cargo build -p collateral-vault --target wasm32-unknown-unknown --release
+        run: cargo build -p collateral-vault --target wasm32v1-none --release
 
       - name: Run Cargo tests
         run: cargo test --workspace --all-features --verbose

--- a/contracts/collateral-vault/src/tests/test_upgrade.rs
+++ b/contracts/collateral-vault/src/tests/test_upgrade.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{token, Address, Bytes, BytesN, Env, IntoVal};
 
 const TEST_WASM: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
-    "/../../target/wasm32-unknown-unknown/release/collateral_vault.wasm"
+    "/../../target/wasm32v1-none/release/collateral_vault.wasm"
 ));
 
 fn setup_env() -> (

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel  = "stable"
 components = ["rustfmt", "clippy"]
-targets  = ["wasm32-unknown-unknown"]
+targets  = ["wasm32v1-none"]


### PR DESCRIPTION
## **User description**
README and docs/CONTRIBUTING.md instruct installing `wasm32v1-none` and building with `--target wasm32v1-none`, but the CI workflow and the vault upgrade test still used `wasm32-unknown-unknown`. Align them so local follow-the-docs builds and CI write WASM to the same path and match what Soroban expects.

- .github/workflows/contract.yml: switch every --target / job name from wasm32-unknown-unknown to wasm32v1-none.
- rust-toolchain.toml: declare `wasm32v1-none` instead of wasm32-unknown-unknown so rustup provisions the target CI relies on.
- contracts/collateral-vault/src/tests/test_upgrade.rs: point the include_bytes! at target/wasm32v1-none/release/collateral_vault.wasm.

No contract logic changed.

closes #643


___

## **CodeAnt-AI Description**
Align CI and upgrade tests with the documented WASM target

### What Changed
- CI now builds all contracts with `wasm32v1-none`
- Upgrade tests load the WASM artifact from the matching build location
- Rust toolchain setup installs the target required by CI

### Impact
`✅ Reliable contract builds in CI`
`✅ Upgrade tests use the generated WASM artifact`
`✅ Consistent local and CI build paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
