### PR TITLE
fix(vault): return Result from remaining admin setters

### DIFF
--- a/contracts/collateral-vault/src/admin.rs
+++ b/contracts/collateral-vault/src/admin.rs
@@ -20,13 +20,13 @@ pub fn set_admin(env: Env, new_admin: Address) -> Result<(), VaultError> {
     Ok(())
 }
 
-pub fn set_lending_pool(env: Env, lending_pool: Address) {
-    let admin = storage::get_admin(&env).expect("not initialized");
+pub fn set_lending_pool(env: Env, lending_pool: Address) -> Result<(), VaultError> {
+    let admin = storage::get_admin(&env).ok_or(VaultError::NotInitialized)?;
     admin.require_auth();
 
     if let Some(oracle) = storage::get_oracle(&env) {
         if lending_pool == oracle {
-            soroban_sdk::panic_with_error!(&env, VaultError::InvalidAddress);
+            return Err(VaultError::InvalidAddress);
         }
     }
 
@@ -39,15 +39,17 @@ pub fn set_lending_pool(env: Env, lending_pool: Address) {
         new_pool: lending_pool,
     }
     .publish(&env);
+
+    Ok(())
 }
 
-pub fn set_oracle(env: Env, oracle: Address) {
-    let admin = storage::get_admin(&env).expect("not initialized");
+pub fn set_oracle(env: Env, oracle: Address) -> Result<(), VaultError> {
+    let admin = storage::get_admin(&env).ok_or(VaultError::NotInitialized)?;
     admin.require_auth();
 
     if let Some(pool) = storage::get_lending_pool(&env) {
         if oracle == pool {
-            soroban_sdk::panic_with_error!(&env, VaultError::InvalidAddress);
+            return Err(VaultError::InvalidAddress);
         }
     }
 
@@ -59,10 +61,12 @@ pub fn set_oracle(env: Env, oracle: Address) {
         new_oracle: oracle,
     }
     .publish(&env);
+
+    Ok(())
 }
 
-pub fn set_liquidation_engine(env: Env, engine: Address) {
-    let admin = storage::get_admin(&env).expect("not initialized");
+pub fn set_liquidation_engine(env: Env, engine: Address) -> Result<(), VaultError> {
+    let admin = storage::get_admin(&env).ok_or(VaultError::NotInitialized)?;
     admin.require_auth();
 
     let old_engine = storage::get_liquidation_engine(&env);
@@ -73,14 +77,16 @@ pub fn set_liquidation_engine(env: Env, engine: Address) {
         new_engine: engine,
     }
     .publish(&env);
+
+    Ok(())
 }
 
-pub fn pause_operation(env: Env, operation: PauseFlag, reason: Symbol) {
-    let admin = storage::get_admin(&env).expect("not initialized");
+pub fn pause_operation(env: Env, operation: PauseFlag, reason: Symbol) -> Result<(), VaultError> {
+    let admin = storage::get_admin(&env).ok_or(VaultError::NotInitialized)?;
     admin.require_auth();
 
     if storage::is_operation_paused(&env, &operation) {
-        soroban_sdk::panic_with_error!(&env, VaultError::AlreadyPaused);
+        return Err(VaultError::AlreadyPaused);
     }
 
     let mask = storage::get_pause_mask(&env);
@@ -93,16 +99,18 @@ pub fn pause_operation(env: Env, operation: PauseFlag, reason: Symbol) {
         reason,
     }
     .publish(&env);
+
+    Ok(())
 }
 
 /// Unpause a specific operation. Only callable by the admin (emergency role).
-/// Panics if the operation is not currently paused.
-pub fn unpause_operation(env: Env, operation: PauseFlag) {
-    let admin = storage::get_admin(&env).expect("not initialized");
+/// Returns an error if the operation is not currently paused.
+pub fn unpause_operation(env: Env, operation: PauseFlag) -> Result<(), VaultError> {
+    let admin = storage::get_admin(&env).ok_or(VaultError::NotInitialized)?;
     admin.require_auth();
 
     if !storage::is_operation_paused(&env, &operation) {
-        soroban_sdk::panic_with_error!(&env, VaultError::NotPaused);
+        return Err(VaultError::NotPaused);
     }
 
     let mask = storage::get_pause_mask(&env);
@@ -114,4 +122,6 @@ pub fn unpause_operation(env: Env, operation: PauseFlag) {
         operation: op_symbol,
     }
     .publish(&env);
+
+    Ok(())
 }

--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -79,23 +79,27 @@ impl VaultContract {
         admin::set_admin(env, new_admin)
     }
 
-    pub fn set_lending_pool(env: Env, lending_pool: Address) {
+    pub fn set_lending_pool(env: Env, lending_pool: Address) -> Result<(), VaultError> {
         admin::set_lending_pool(env, lending_pool)
     }
 
-    pub fn set_oracle(env: Env, oracle: Address) {
+    pub fn set_oracle(env: Env, oracle: Address) -> Result<(), VaultError> {
         admin::set_oracle(env, oracle)
     }
 
-    pub fn set_liquidation_engine(env: Env, engine: Address) {
+    pub fn set_liquidation_engine(env: Env, engine: Address) -> Result<(), VaultError> {
         admin::set_liquidation_engine(env, engine)
     }
 
-    pub fn pause_operation(env: Env, operation: PauseFlag, reason: Symbol) {
+    pub fn pause_operation(
+        env: Env,
+        operation: PauseFlag,
+        reason: Symbol,
+    ) -> Result<(), VaultError> {
         admin::pause_operation(env, operation, reason)
     }
 
-    pub fn unpause_operation(env: Env, operation: PauseFlag) {
+    pub fn unpause_operation(env: Env, operation: PauseFlag) -> Result<(), VaultError> {
         admin::unpause_operation(env, operation)
     }
 

--- a/contracts/collateral-vault/src/tests/test_admin.rs
+++ b/contracts/collateral-vault/src/tests/test_admin.rs
@@ -132,12 +132,7 @@ fn test_initialize_sets_paused_false() {
     ) = setup_env();
 
     let res = client.try_unpause_operation(&PauseFlag::Deposit);
-    assert_eq!(
-        res,
-        Err(Ok(soroban_sdk::Error::from_contract_error(
-            VaultError::NotPaused as u32
-        )))
-    );
+    assert_eq!(res, Err(Ok(VaultError::NotPaused)));
 }
 
 #[test]
@@ -157,12 +152,7 @@ fn test_set_lending_pool_oracle_collision_fails() {
 
     // Setting lending_pool equal to current oracle should fail
     let res = client.try_set_lending_pool(&oracle);
-    assert_eq!(
-        res,
-        Err(Ok(soroban_sdk::Error::from_contract_error(
-            VaultError::InvalidAddress as u32
-        )))
-    );
+    assert_eq!(res, Err(Ok(VaultError::InvalidAddress)));
 }
 
 #[test]
@@ -182,12 +172,7 @@ fn test_set_oracle_lending_pool_collision_fails() {
 
     // Setting oracle equal to current lending_pool should fail
     let res = client.try_set_oracle(&lending_pool);
-    assert_eq!(
-        res,
-        Err(Ok(soroban_sdk::Error::from_contract_error(
-            VaultError::InvalidAddress as u32
-        )))
-    );
+    assert_eq!(res, Err(Ok(VaultError::InvalidAddress)));
 }
 
 // ── Admin transfer tests ───────────────────────────────────────────────
@@ -589,4 +574,58 @@ fn test_set_admin_same_address() {
 
     let result = client.try_set_admin(&admin);
     assert_eq!(result, Err(Ok(VaultError::AlreadyAdmin)));
+}
+
+// ── Uninitialized admin calls return Err (not `expect` panic) ──────────
+
+#[test]
+fn test_uninitialized_admin_setters_return_err() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let some_addr = Address::generate(&env);
+
+    assert_eq!(
+        client.try_set_lending_pool(&some_addr),
+        Err(Ok(VaultError::NotInitialized))
+    );
+    assert_eq!(
+        client.try_set_oracle(&some_addr),
+        Err(Ok(VaultError::NotInitialized))
+    );
+    assert_eq!(
+        client.try_set_liquidation_engine(&some_addr),
+        Err(Ok(VaultError::NotInitialized))
+    );
+    assert_eq!(
+        client.try_pause_operation(&PauseFlag::Deposit, &Symbol::new(&env, "reason")),
+        Err(Ok(VaultError::NotInitialized))
+    );
+    assert_eq!(
+        client.try_unpause_operation(&PauseFlag::Deposit),
+        Err(Ok(VaultError::NotInitialized))
+    );
+
+    // Nothing should have been set: the admin is still uninitialized
+    assert_eq!(client.get_admin(), None);
+}
+
+#[test]
+fn test_uninitialized_set_admin_returns_err() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    // set_admin already behaves this way and the issue requires it remain unchanged.
+    // Calling it on an uninitialized contract should return InvalidInputs.
+    let some_addr = Address::generate(&env);
+    assert_eq!(
+        client.try_set_admin(&some_addr),
+        Err(Ok(VaultError::InvalidInputs))
+    );
 }


### PR DESCRIPTION
## **User description**
set_lending_pool, set_oracle, set_liquidation_engine, pause_operation and unpause_operation now return Result<(), VaultError>, using ok_or(VaultError:: NotInitialized) instead of expect("not initialized") panics. Collision and pause-flag checks are returned as Err instead of raised via panic, so callers can handle the failures as Result. The public VaultContract impl threads the Result through and tests are updated to match the Result-based behavior.

closes #651


___

## **CodeAnt-AI Description**
Return recoverable errors from vault admin operations instead of panicking

### What Changed
- Admin setters and pause controls now return explicit success or `VaultError` results for uninitialized contracts, address conflicts, and invalid pause state.
- Callers can handle failures from lending pool, oracle, liquidation engine, pause, and unpause operations without triggering a panic.
- Added coverage for uninitialized admin calls and updated error expectations for validation failures.

### Impact
`✅ Fewer vault admin panics`
`✅ Clearer configuration and pause-operation errors`
`✅ Safer handling of uninitialized contracts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
