### PR TITLE
Fix/vault reject address collisions on initialize

### DIFF
--- a/contracts/collateral-vault/src/lib.rs
+++ b/contracts/collateral-vault/src/lib.rs
@@ -34,7 +34,13 @@ impl VaultContract {
             return Err(VaultError::AlreadyInitialized);
         }
 
-        if lending_pool == oracle {
+        if admin == lending_pool
+            || admin == oracle
+            || admin == liquidation_engine
+            || lending_pool == oracle
+            || lending_pool == liquidation_engine
+            || oracle == liquidation_engine
+        {
             return Err(VaultError::InvalidAddress);
         }
 

--- a/contracts/collateral-vault/src/tests/test_admin.rs
+++ b/contracts/collateral-vault/src/tests/test_admin.rs
@@ -100,10 +100,54 @@ fn test_initialize_duplicate_fails() {
 }
 
 #[test]
+fn test_initialize_admin_equals_lending_pool_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let same_address = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let engine = Address::generate(&env);
+
+    let result = client.try_initialize(&same_address, &same_address, &oracle, &engine);
+    assert_eq!(result, Err(Ok(VaultError::InvalidAddress)));
+}
+
+#[test]
+fn test_initialize_admin_equals_oracle_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let same_address = Address::generate(&env);
+    let pool = Address::generate(&env);
+    let engine = Address::generate(&env);
+
+    let result = client.try_initialize(&same_address, &pool, &same_address, &engine);
+    assert_eq!(result, Err(Ok(VaultError::InvalidAddress)));
+}
+
+#[test]
+fn test_initialize_admin_equals_liquidation_engine_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let same_address = Address::generate(&env);
+    let pool = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    let result = client.try_initialize(&same_address, &pool, &oracle, &same_address);
+    assert_eq!(result, Err(Ok(VaultError::InvalidAddress)));
+}
+
+#[test]
 fn test_initialize_pool_equals_oracle_fails() {
     let env = Env::default();
     env.mock_all_auths();
-
     let contract_id = env.register(VaultContract, ());
     let client = VaultContractClient::new(&env, &contract_id);
 
@@ -111,8 +155,37 @@ fn test_initialize_pool_equals_oracle_fails() {
     let same_address = Address::generate(&env);
     let engine = Address::generate(&env);
 
-    // lending_pool == oracle should be rejected
     let result = client.try_initialize(&admin, &same_address, &same_address, &engine);
+    assert_eq!(result, Err(Ok(VaultError::InvalidAddress)));
+}
+
+#[test]
+fn test_initialize_pool_equals_liquidation_engine_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let same_address = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    let result = client.try_initialize(&admin, &same_address, &oracle, &same_address);
+    assert_eq!(result, Err(Ok(VaultError::InvalidAddress)));
+}
+
+#[test]
+fn test_initialize_oracle_equals_liquidation_engine_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(VaultContract, ());
+    let client = VaultContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pool = Address::generate(&env);
+    let same_address = Address::generate(&env);
+
+    let result = client.try_initialize(&admin, &pool, &same_address, &same_address);
     assert_eq!(result, Err(Ok(VaultError::InvalidAddress)));
 }
 


### PR DESCRIPTION
Closes #650

### Overview
Updated `VaultContract::initialize` to validate that all four parameters (`admin`, `lending_pool`, `oracle`, and `liquidation_engine`) are pairwise distinct addresses to prevent configuration footguns.

### Changes Made
- Updated `VaultContract::initialize` in `contracts/collateral-vault/src/lib.rs` to reject any pairwise collision among `admin`, `lending_pool`, `oracle`, and `liquidation_engine` with `VaultError::InvalidAddress`.
- Added unit tests in `contracts/collateral-vault/src/tests/test_admin.rs` for all 6 pairwise address collision scenarios on initialization.