### PR TITLE
Add private vulnerability reporting policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ A good first step is to browse the [open issues](https://github.com/Alien-Protoc
 
 ## 🔐 Security
 
-If you discover a security vulnerability, please avoid opening a public issue that exposes it. Contact the maintainers privately through the repository owner's GitHub profile until a dedicated security policy and reporting channel are published.
+If you discover a security vulnerability, do not open a public issue that
+exposes it. Follow the private reporting instructions in our
+[Security Policy](SECURITY.md).
 
 ## 📄 License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Do not open a public issue, discussion, or pull request for a vulnerability
+that could be exploited. Public reports can expose users before a fix is
+available.
+
+Report the vulnerability privately using GitHub's
+[private vulnerability reporting form](https://github.com/Alien-Protocol/Alien-Protocol/security/advisories/new).
+If that form is unavailable, contact the maintainers through the
+[repository owner's GitHub profile](https://github.com/Alien-Protocol) and ask
+for a private security contact. Do not include exploit details in a public
+profile message.
+
+Please include, where possible:
+
+- the affected contract, component, commit, or release;
+- reproduction steps or a minimal proof of concept;
+- the expected and observed behavior;
+- the potential impact and required attacker capabilities; and
+- any suggested mitigation.
+
+Avoid accessing data that is not yours, disrupting deployed services, or
+performing tests against production without explicit authorization. Keep the
+report private while maintainers investigate and coordinate a fix and
+disclosure.
+
+## Supported code
+
+Security fixes are made against the current default `drip` branch. Reports for
+older commits are still useful when the affected code remains in the current
+branch; please identify the version you tested.
+
+This project does not currently publish a bug-bounty or reward program. This
+policy defines the reporting path only and does not promise compensation or a
+specific response timeline.


### PR DESCRIPTION
## **User description**
## Summary

Adds the repository's missing security policy and replaces the README's temporary guidance with a direct link to a concrete private reporting path.

## Issue

Closes #645

## User and reporter impact

The README warned reporters not to disclose exploitable vulnerabilities publicly, but it also said a dedicated policy would be published later. That left responsible reporters without repository-level instructions and made GitHub's standard security-policy discovery unavailable.

## Changes

- Add `SECURITY.md` at GitHub's recognized repository-root location.
- Direct exploitable reports to GitHub's private vulnerability reporting form.
- Provide the existing repository-owner profile as a fallback when the private form is unavailable, without asking reporters to publish exploit details there.
- Document the useful contents of a report, safe-testing expectations, coordinated disclosure, and the currently supported default branch.
- State explicitly that this reporting policy does not create a bounty, compensation promise, or response-time commitment.
- Replace the README's temporary language with a link to the policy.

## Validation

- `git diff --check` passed.
- Verified that the README link resolves to the new root `SECURITY.md` file.
- No product, contract, or security-feature code was changed.

## Notes

This PR only establishes a responsible private reporting route. It intentionally does not invent a bug-bounty program or operational SLA.


___

## **CodeAnt-AI Description**
Add clear private reporting instructions for security vulnerabilities

### What Changed
- Security reports are directed to GitHub’s private vulnerability reporting form instead of public issues, discussions, or pull requests
- A fallback private contact path is provided when the form is unavailable
- Reporters receive guidance on useful report details, safe testing, supported code, and coordinated disclosure
- The README now links directly to the security policy
- The policy clarifies that there is no bug bounty, compensation promise, or response-time commitment

### Impact
`✅ Private vulnerability disclosure`
`✅ Clearer security reporting steps`
`✅ Safer security testing and coordination`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
