### PR TITLE
[codex] test shared math edge cases

### DIFF
--- a/contracts/shared/src/tests.rs
+++ b/contracts/shared/src/tests.rs
@@ -46,6 +46,22 @@ fn test_health_factor_zero_debt_is_max() {
 }
 
 #[test]
+fn test_health_factor_rejects_negative_debt() {
+    assert_eq!(
+        health_factor_bps(10_000, -1, 8_000),
+        Err(SharedError::InvalidAmount)
+    );
+}
+
+#[test]
+fn test_health_factor_rejects_negative_collateral() {
+    assert_eq!(
+        health_factor_bps(-1, 7_500, 8_000),
+        Err(SharedError::InvalidAmount)
+    );
+}
+
+#[test]
 fn test_borrow_limit_seventy_percent() {
     assert_eq!(
         borrow_limit_from_collateral(10_000_000, 7_000).unwrap(),
@@ -60,4 +76,9 @@ fn test_ceil_div_rounds_up() {
     assert_eq!(ceil_div(1, 3).unwrap(), 1);
     assert_eq!(ceil_div(0, 3).unwrap(), 0);
     assert_eq!(ceil_div(5, -2).unwrap(), -2);
+}
+
+#[test]
+fn test_ceil_div_rejects_zero_denominator() {
+    assert_eq!(ceil_div(1, 0), Err(SharedError::DivisionByZero));
 }

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -78,6 +78,9 @@ pub fn health_factor_bps(
     debt: i128,
     liquidation_threshold_bps: u32,
 ) -> Result<i128, SharedError> {
+    if collateral_value < 0 {
+        return Err(SharedError::InvalidAmount);
+    }
     if debt == 0 {
         return Ok(i128::MAX);
     }


### PR DESCRIPTION
## **User description**
## Summary

This PR closes #656 by expanding the shared math edge-case contract and making health-factor validation consistent with the existing borrow-limit validation.

## Problem

The shared math tests covered normal ceiling division and healthy health-factor inputs, but did not lock down three important invalid-input paths. A zero denominator in `ceil_div` and negative debt in `health_factor_bps` already returned typed errors but had no regression coverage. Negative collateral was not rejected at all, allowing a nonsensical negative health factor to flow to callers.

## Root cause

`health_factor_bps` validated debt but did not apply the same negative-collateral guard already used by `borrow_limit_from_collateral`. The missing edge-case tests left this inconsistency undocumented and unprotected.

## Changes

- Reject negative `collateral_value` in `health_factor_bps` with `SharedError::InvalidAmount`.
- Add regression coverage for negative collateral.
- Add regression coverage confirming negative debt returns `SharedError::InvalidAmount`.
- Add regression coverage confirming `ceil_div(1, 0)` returns `SharedError::DivisionByZero`.
- Keep all existing formulas and successful-input behavior unchanged.

## User impact

Invalid collateral values now fail explicitly instead of producing a misleading negative health factor. Callers can consistently handle invalid amounts through the shared typed error API.

## Validation

- `git diff --check` — passed.
- `cargo test -p shared` — attempted as required, but the command produced no output and timed out in the local environment after 124 seconds. No unrelated build or CI changes were made.

Closes #656


___

## **CodeAnt-AI Description**
Reject invalid inputs in shared financial calculations

### What Changed
- Health-factor calculations now reject negative collateral and negative debt with a typed invalid-amount error
- Division calculations explicitly reject a zero denominator with a division-by-zero error
- Added regression coverage for these invalid-input cases

### Impact
`✅ Prevents misleading health factors from negative collateral`
`✅ Clearer errors for invalid debt and collateral values`
`✅ Safer handling of zero-denominator calculations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
